### PR TITLE
Some UI refactoring (WIP)

### DIFF
--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -181,5 +181,7 @@ class Interactive(object):
                               conf,
                               title='select an event',
                               description='do something')
-        ui.start_pane(pane, pane.cleanup,
-                      header=u'{0} v{1}'.format(__productname__, __version__))
+        ui.start_pane(
+            pane, pane.cleanup,
+            program_info=u'{0} v{1}'.format(__productname__, __version__)
+        )

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -84,6 +84,10 @@ class Calendar(object):
         if self._db_needs_update():
             self.db_update()
 
+    @property
+    def readonly(self):
+        return self._readonly
+
     def _cover_event(self, event):
         event.color = self.color
         event.readonly = self._readonly
@@ -205,11 +209,6 @@ class CalendarCollection(object):
     @property
     def names(self):
         return self._calnames.keys()
-
-    @property
-    def writable_names(self):
-        return [cal for cal in self._calnames
-                if not self._calnames[cal]._readonly]
 
     @property
     def default_calendar_name(self):

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -203,6 +203,10 @@ class CalendarCollection(object):
         self._default_calendar_name = None
 
     @property
+    def writable_names(self):
+        return [c.name for c in self.calendars if not c.readonly]
+
+    @property
     def calendars(self):
         return self._calnames.values()
 
@@ -214,10 +218,9 @@ class CalendarCollection(object):
     def default_calendar_name(self):
         if self._default_calendar_name in self.names:
             return self._default_calendar_name
-        elif len(self.writable_names) > 0:
-            return self.writable_names[0]
         else:
-            return self._calnames.values()[0].name
+            names = self.writable_names or self.names
+            return names[0]
 
     def append(self, calendar):
         self._calnames[calendar.name] = calendar

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -532,8 +532,7 @@ class EventColumn(urwid.WidgetWrap):
         """
         self.destroy()
         self.editor = True
-        editor = EventEditor(self.pane.conf, event,
-                             collection=self.pane.collection)
+        editor = EventEditor(self.pane, event)
 
         def teardown(data):
             self.editor = False
@@ -596,9 +595,7 @@ class EventViewer(urwid.WidgetWrap):
     Base Class for EventEditor and EventDisplay
     """
 
-    def __init__(self, conf, collection):
-        self.conf = conf
-        self.collection = collection
+    def __init__(self):
         pile = CPile([])
         urwid.WidgetWrap.__init__(self, pile)
 
@@ -611,7 +608,11 @@ class EventDisplay(EventViewer):
     """
 
     def __init__(self, conf, event, collection=None):
-        super(EventDisplay, self).__init__(conf, collection)
+        super(EventDisplay, self).__init__()
+
+        self.conf = conf
+        self.collection = collection
+
         lines = []
         lines.append(urwid.Text(event.vevent['SUMMARY']))
 
@@ -656,20 +657,23 @@ class EventDisplay(EventViewer):
         self._w = urwid.Filler(pile, valign='top')
 
 
-class EventEditor(EventViewer, Config):
+class EventEditor(urwid.WidgetWrap, Config):
 
     """
     Widget for event Editing
     """
 
-    def __init__(self, conf, event, collection=None):
+    def __init__(self, pane, event):
         """
         :type event: khal.event.Event
-        :param cancel: to be executed on pressing the cancel button
-        :type cancel: function/method
         """
-        super(EventEditor, self).__init__(conf, collection)
+
+        self.pane = pane
         self.event = event
+
+        self.collection = pane.collection
+        self.conf = pane.conf
+
         try:
             self.description = event.vevent['DESCRIPTION']
         except KeyError:
@@ -711,7 +715,7 @@ class EventEditor(EventViewer, Config):
              self.location, urwid.Text(''), save
              ]))
 
-        self._w = self.pile
+        urwid.WidgetWrap.__init__(self, self.pile)
 
     @property
     def title(self):  # Window title

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -23,6 +23,7 @@
 import calendar
 from datetime import date, datetime, time, timedelta
 import signal
+import sys
 
 import urwid
 
@@ -867,4 +868,14 @@ def start_pane(pane, callback, header=''):
         raise urwid.ExitMainLoop()
 
     signal.signal(signal.SIGINT, ctrl_c)
-    loop.run()
+    try:
+        loop.run()
+    except Exception:
+        import traceback
+        tb = traceback.format_exc()
+        try:  # Try to leave terminal in usable state
+            loop.stop()
+        except Exception:
+            pass
+        print(tb)
+        sys.exit(1)

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -190,7 +190,7 @@ class DateCColumns(CColumns):
         if key in self.keys['view']:
             self._old_attr_map = self.contents[self.focus_position][0].get_attr_map()
             self._old_pos = old_pos
-            self.contents[self.focus_position][0].set_attr_map({None: 'today_focus'})
+            self.contents[self.focus_position][0].set_attr_map({None: 'today focus'})
             return 'right'
         elif self._old_attr_map:
             self.contents[self._old_pos][0].set_attr_map(self._old_attr_map)
@@ -329,7 +329,7 @@ class CalendarWalker(urwid.SimpleFocusListWalker):
         for number, day in enumerate(week):
             if day == date.today():
                 this_week.append((2, urwid.AttrMap(Date(day, self.pane),
-                                                   'today', 'today_focus')))
+                                                   'today', 'today focus')))
                 today = number + 1
             else:
                 this_week.append((2, urwid.AttrMap(Date(day, self.pane),

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -572,8 +572,8 @@ class EventColumn(urwid.WidgetWrap):
                               timezone=self.pane.conf['locale']['default_timezone'])
 
         # TODO proper default cal
-        event = self.collection.new_event(
-            event.to_ical(), self.collection.default_calendar_name)
+        event = self.pane.collection.new_event(
+            event.to_ical(), self.pane.collection.default_calendar_name)
 
         self.edit(event)
         self.eventcount += 1

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -686,26 +686,31 @@ class EventEditor(urwid.WidgetWrap, Config):
         except KeyError:
             rrule = None
         self.recursioneditor = RecursionEditor(rrule)
-        self.summary = Edit(
-            edit_text=event.vevent['SUMMARY'])
+        self.summary = Edit(edit_text=event.vevent['SUMMARY'])
+
+        divider = urwid.Divider(' ')
+
         # TODO warning message if len(self.collection.writable_names) == 0
         self.accountchooser = AccountChooser(self.event.calendar,
                                              self.collection.writable_names)
-        accounts = CColumns([(9, urwid.Text(u'Calendar: ')),
-                             self.accountchooser])
         self.description = Edit(caption=u'Description: ',
                                 edit_text=self.description)
         self.location = Edit(caption=u'Location: ',
                              edit_text=self.location)
-        save = urwid.Button(u'Save', on_press=self.save)
-
-        self.pile = urwid.ListBox(CSimpleFocusListWalker(
-            [self.summary,
-             accounts,
-             self.startendeditor,
-             self.recursioneditor, self.description,
-             self.location, urwid.Text(''), save
-             ]))
+        self.pile = urwid.ListBox(CSimpleFocusListWalker([
+            urwid.Columns([
+                self.summary,
+                self.accountchooser
+            ], dividechars=2),
+            divider,
+            self.description,
+            self.location,
+            divider,
+            self.startendeditor,
+            self.recursioneditor,
+            divider,
+            urwid.Button(u'Save', on_press=self.save)
+        ]))
 
         urwid.WidgetWrap.__init__(self, self.pile)
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -488,7 +488,7 @@ class EventList(urwid.WidgetWrap):
 
 class EventColumn(urwid.WidgetWrap):
 
-    """contains the eventlist as well as the event viewer/editor"""
+    """contains the eventlist as well as the event viewer"""
 
     def __init__(self, pane):
         self.pane = pane
@@ -545,7 +545,7 @@ class EventColumn(urwid.WidgetWrap):
             self.update(self.date)
         self.editor = False
         if (len(self.container.contents) > 2 and
-                isinstance(self.container.contents[2][0], EventViewer)):
+                isinstance(self.container.contents[2][0], EventDisplay)):
             self.container.contents.pop()
             self.container.contents.pop()
 
@@ -586,18 +586,7 @@ class RecursionEditor(urwid.WidgetWrap):
                                           self.columns.options()))
 
 
-class EventViewer(urwid.WidgetWrap):
-
-    """
-    Base Class for EventEditor and EventDisplay
-    """
-
-    def __init__(self):
-        pile = CPile([])
-        urwid.WidgetWrap.__init__(self, pile)
-
-
-class EventDisplay(EventViewer):
+class EventDisplay(urwid.WidgetWrap):
 
     """showing events
 
@@ -605,8 +594,6 @@ class EventDisplay(EventViewer):
     """
 
     def __init__(self, conf, event, collection=None):
-        super(EventDisplay, self).__init__()
-
         self.conf = conf
         self.collection = collection
 
@@ -651,7 +638,7 @@ class EventDisplay(EventViewer):
                 pass
 
         pile = CPile(lines)
-        self._w = urwid.Filler(pile, valign='top')
+        urwid.WidgetWrap.__init__(self, urwid.Filler(pile, valign='top'))
 
 
 class EventEditor(urwid.WidgetWrap, Config):

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -527,23 +527,16 @@ class EventColumn(urwid.WidgetWrap):
         :param event: event to edit
         :type event: khal.event.Event
         """
-        self.destroy()
         self.editor = True
         editor = EventEditor(self.pane, event)
 
         def teardown(data):
             self.editor = False
             self.update(self.date)
-            self.destroy()
         self.pane.window.open(editor, callback=teardown)
 
-    def destroy(self, _=None, refresh=False):
-        """
-        if an EventViewer or EventEditor is displayed, remove it
-        """
-        if refresh and self.date is not None:
-            self.update(self.date)
-        self.editor = False
+    def destroy(self):
+        """if an event is displayed, remove it"""
         if (len(self.container.contents) > 2 and
                 isinstance(self.container.contents[2][0], EventDisplay)):
             self.container.contents.pop()

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -532,6 +532,10 @@ class EventColumn(urwid.WidgetWrap):
         :param event: event to edit
         :type event: khal.event.Event
         """
+        if self.editor:
+            self.pane.window.backtrack()
+
+        assert not self.editor
         self.editor = True
         editor = EventEditor(self.pane, event)
         current_day = self.container.contents[0][0]

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -558,10 +558,9 @@ class EventColumn(urwid.WidgetWrap):
 
     def destroy(self):
         """if an event is displayed, remove it"""
-        if (len(self.container.contents) > 2 and
-                isinstance(self.container.contents[2][0], EventDisplay)):
+        while len(self.container.contents) > 1:
             self.container.contents.pop()
-            self.container.contents.pop()
+        self.current_event = None
 
     def new(self, date):
         """create a new event on date

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -534,11 +534,18 @@ class EventColumn(urwid.WidgetWrap):
         """
         self.editor = True
         editor = EventEditor(self.pane, event)
+        current_day = self.container.contents[0][0]
+        new_pane = urwid.Columns([
+            ('weight', 1.5, editor),
+            ('weight', 1, current_day)
+        ], dividechars=4)
+        new_pane.title = editor.title
+        new_pane.set_focus(0)
 
         def teardown(data):
             self.editor = False
             self.update(self.date)
-        self.pane.window.open(editor, callback=teardown)
+        self.pane.window.open(new_pane, callback=teardown)
 
     def destroy(self):
         """if an event is displayed, remove it"""

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -857,7 +857,7 @@ class ClassicView(Pane):
                 (['t'], 're-focus on today'),
                 (['enter'], 'select a date/event, show/edit event'),
                 (['d'], 'delete event under cursor'),
-                (['q'], 'quit'),
+                (['q', 'esc'], 'previous pane/quit'),
                 ]
 
     def show_date(self, date):

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -632,12 +632,11 @@ class EventEditor(urwid.WidgetWrap):
 
         # TODO warning message if len(self.collection.writable_names) == 0
 
-        def decorate_choice(name):
-            c = self.collection._calnames[name]
-            return (c.color or '', name)
+        def decorate_choice(c):
+            return (c.color or '', c.name)
 
-        self.accountchooser = Choice(
-            [c.name for c in self.collection.calendars if not c.readonly],
+        self.calendar_chooser = Choice(
+            [c for c in self.collection.calendars if not c.readonly],
             self.event.calendar,
             decorate_choice
         )
@@ -648,7 +647,7 @@ class EventEditor(urwid.WidgetWrap):
         self.pile = urwid.ListBox(CSimpleFocusListWalker([
             urwid.Columns([
                 self.summary,
-                self.accountchooser
+                self.calendar_chooser
             ], dividechars=2),
             divider,
             self.description,
@@ -688,7 +687,7 @@ class EventEditor(urwid.WidgetWrap):
                 self.event.vevent.get('LOCATION', ''):
             return True
 
-        if self.startendeditor.changed or self.accountchooser.changed:
+        if self.startendeditor.changed or self.calendar_chooser.changed:
             return True
         return False
 
@@ -716,7 +715,7 @@ class EventEditor(urwid.WidgetWrap):
                             self.startendeditor.newstart)
                 self.event.vevent.add('DURATION', duration)
 
-        # TODO self.newaccount = self.accountchooser.account ?
+        # TODO self.newaccount = self.calendar_chooser.active ?
 
     def save(self, button):
         """
@@ -743,11 +742,11 @@ class EventEditor(urwid.WidgetWrap):
             self.event.allday = self.startendeditor.allday
             if self.event.etag is None:  # has not been saved before
                 # TODO look for better way to detect this
-                self.event.calendar = self.accountchooser.account
+                self.event.calendar = self.calendar_chooser.active
                 self.collection.new(self.event)
-            elif self.accountchooser.changed:
+            elif self.calendar_chooser.changed:
                 self.collection.change_collection(self.event,
-                                                  self.accountchooser.account)
+                                                  self.calendar_chooser.active)
             else:
                 self.collection.update(self.event)
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -782,7 +782,9 @@ class EventEditor(urwid.WidgetWrap, Config):
                        self.startendeditor.bgs.endtime]:
             self.startendeditor.refresh(None, state=self.startendeditor.allday)
             self.pile.set_focus(1)  # the startendeditor
-        elif changed is True:
+            return
+
+        if changed is True:
             try:
                 self.event.vevent['SEQUENCE'] += 1
             except KeyError:
@@ -798,6 +800,8 @@ class EventEditor(urwid.WidgetWrap, Config):
                                                   self.accountchooser.account)
             else:
                 self.collection.update(self.event)
+
+        self.pane.window.backtrack()
 
     def keypress(self, size, key):
         if key in ['esc']:  # TODO XXX

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -420,8 +420,10 @@ class U_Event(urwid.Text):
         self.set_text(mark + ' ' + self.event.compact(self.this_date))
 
     def toggle_delete(self):
-        if self.event.readonly is True:
-            self.set_title('RO')
+        if self.event.readonly:
+            self.eventcolumn.pane.window.alert(
+                ('light red',
+                 'Calendar {} is read-only.'.format(self.event.calendar)))
             return
         if self.uid in self.eventcolumn.deleted:
             self.eventcolumn.deleted.remove(self.uid)
@@ -531,7 +533,9 @@ class EventColumn(urwid.WidgetWrap):
         :type event: khal.event.Event
         """
         if event.readonly:
-            self.pane.window.alert(('light red', 'Event is read-only.'))
+            self.pane.window.alert(
+                ('light red',
+                 'Calendar {} is read-only.'.format(event.calendar)))
             return
 
         if self.editor:

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -701,16 +701,14 @@ class EventEditor(EventViewer, Config):
                                 edit_text=self.description)
         self.location = Edit(caption=u'Location: ',
                              edit_text=self.location)
-        cancel = urwid.Button(u'Cancel', on_press=self.cancel)
         save = urwid.Button(u'Save', on_press=self.save)
-        buttons = CColumns([cancel, save])
 
         self.pile = urwid.ListBox(CSimpleFocusListWalker(
             [self.summary,
              accounts,
              self.startendeditor,
              self.recursioneditor, self.description,
-             self.location, urwid.Text(''), buttons
+             self.location, urwid.Text(''), save
              ]))
 
         self._w = self.pile
@@ -811,8 +809,6 @@ class EventEditor(EventViewer, Config):
                                                   self.accountchooser.account)
             else:
                 self.collection.update(self.event)
-
-        self.cancel(refresh=True)
 
     def keypress(self, size, key):
         if key in ['esc']:  # TODO XXX

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -793,16 +793,9 @@ class EventEditor(urwid.WidgetWrap, Config):
         self.pane.window.backtrack()
 
     def keypress(self, size, key):
-        if key in ['esc']:  # TODO XXX
-            if self.changed:
-                return
-            else:
-                return key
-        key = super(EventEditor, self).keypress(size, key)
-        if key in ['left', 'up']:  # TODO XXX
+        if key in ['esc'] and self.changed:  # TODO XXX
             return
-        else:
-            return key
+        return super(EventEditor, self).keypress(size, key)
 
 
 class ClassicView(Pane):

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -863,8 +863,9 @@ class ClassicView(Pane):
     def get_keys(self):
         return [(['arrows'], 'navigate through the calendar'),
                 (['t'], 're-focus on today'),
-                (['enter'], 'select a date/event, show/edit event'),
-                (['d'], 'delete event under cursor'),
+                (['enter', 'tab'], 'select a date/event, show/edit event'),
+                (['n'], 'create event on selected day'),
+                (['d'], 'delete selected event'),
                 (['q', 'esc'], 'previous pane/quit'),
                 ]
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -671,6 +671,8 @@ class EventEditor(urwid.WidgetWrap):
         self.collection = pane.collection
         self.conf = pane.conf
 
+        self._abort_confirmed = False
+
         try:
             self.description = event.vevent['DESCRIPTION']
         except KeyError:
@@ -808,10 +810,16 @@ class EventEditor(urwid.WidgetWrap):
             else:
                 self.collection.update(self.event)
 
+        self._abort_confirmed = False
         self.pane.window.backtrack()
 
     def keypress(self, size, key):
-        if key in ['esc'] and self.changed:  # TODO XXX
+        if key in ['esc'] and self.changed and not self._abort_confirmed:
+            # TODO Use user-defined keybindings
+            self.pane.window.alert(
+                ('light red',
+                 'Unsaved changes! Hit ESC again to discard.'))
+            self._abort_confirmed = True
             return
         return super(EventEditor, self).keypress(size, key)
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -164,19 +164,16 @@ class DateCColumns(CColumns, Config):
     def _set_focus_position(self, position):
         """calls view.show_date before calling super()._set_focus_position"""
 
+        self.view.show_date(
+            self.contents[position][0].original_widget.date)
         super(DateCColumns, self)._set_focus_position(position)
 
-        # since first Column is month name, focus should only be 0 during
-        # construction
-        if not self.contents.focus == 0:
-            self.view.show_date(
-                self.contents[position][0].original_widget.date)
-
-    focus_position = property(CColumns._get_focus_position,
-                              _set_focus_position, doc="""
-index of child widget in focus. Raises IndexError if read when
-CColumns is empty, or when set to an invalid index.
-""")
+    focus_position = property(
+        CColumns._get_focus_position,
+        _set_focus_position,
+        doc=('Index of child widget in focus. Raises IndexError if read when '
+             'CColumns is empty, or when set to an invalid index.')
+    )
 
     def keypress(self, size, key):
         """only leave calendar area on pressing 'tab' or 'enter'"""
@@ -500,15 +497,15 @@ class EventColumn(urwid.WidgetWrap):
         self.date = None
         self.eventcount = 0
 
-    def update(self, date):
-        """create an EventList populated with Events for `date` and display it
-        """
-        self.date = date
         # TODO make this switch from pile to columns depending on terminal size
-        events = EventList(eventcolumn=self)
-        self.eventcount = events.update(date)
-        self.container = CPile([events])
-        self._w = self.container
+        self.events = EventList(eventcolumn=self)
+        self.container = CPile([self.events])
+        urwid.WidgetWrap.__init__(self, self.container)
+
+    def update(self, date):
+        """Show events for the specified date."""
+        self.date = date
+        self.eventcount = self.events.update(date)
 
     def view(self, event):
         """

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -742,19 +742,10 @@ class EventEditor(urwid.WidgetWrap, Config):
             return True
         return False
 
-    def update(self):
-        changed = False
-        if self.summary.get_edit_text() != self.event.vevent['SUMMARY']:
-            self.event.vevent['SUMMARY'] = self.summary.get_edit_text()
-            changed = True
-
-        for key, prop in [
-            ('DESCRIPTION', self.description),
-            ('LOCATION', self.location)
-        ]:
-            if prop.get_edit_text() != self.event.vevent.get(key, ''):
-                self.event.vevent[key] = prop.get_edit_text()
-                changed = True
+    def update_vevent(self):
+        self.event.vevent['SUMMARY'] = self.summary.get_edit_text()
+        self.event.vevent['DESCRIPTION'] = self.description.get_edit_text()
+        self.event.vevent['LOCATION'] = self.location.get_edit_text()
 
         if self.startendeditor.changed:
             # TODO look up why this is needed
@@ -775,11 +766,7 @@ class EventEditor(urwid.WidgetWrap, Config):
                             self.startendeditor.newstart)
                 self.event.vevent.add('DURATION', duration)
 
-            changed = True
-        if self.accountchooser.changed:
-            changed = True
-            # TODO self.newaccount = self.accountchooser.account ?
-        return changed
+        # TODO self.newaccount = self.accountchooser.account ?
 
     def save(self, button):
         """
@@ -788,16 +775,14 @@ class EventEditor(urwid.WidgetWrap, Config):
         """
         # need to call this to set date backgrounds to False
         changed = self.changed
-        self.update()
+        self.update_vevent()
         if 'alert' in [self.startendeditor.bgs.startdate,
                        self.startendeditor.bgs.starttime,
                        self.startendeditor.bgs.enddate,
                        self.startendeditor.bgs.endtime]:
             self.startendeditor.refresh(None, state=self.startendeditor.allday)
             self.pile.set_focus(1)  # the startendeditor
-            return
-
-        if changed is True:
+        elif changed is True:
             try:
                 self.event.vevent['SEQUENCE'] += 1
             except KeyError:

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -530,6 +530,10 @@ class EventColumn(urwid.WidgetWrap):
         :param event: event to edit
         :type event: khal.event.Event
         """
+        if event.readonly:
+            self.pane.window.alert(('light red', 'Event is read-only.'))
+            return
+
         if self.editor:
             self.pane.window.backtrack()
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -538,9 +538,8 @@ class EventColumn(urwid.WidgetWrap):
         new_pane = urwid.Columns([
             ('weight', 1.5, editor),
             ('weight', 1, current_day)
-        ], dividechars=4)
+        ], dividechars=4, focus_column=0)
         new_pane.title = editor.title
-        new_pane.set_focus(0)
 
         def teardown(data):
             self.editor = False

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -544,6 +544,7 @@ class EventColumn(urwid.WidgetWrap):
             ('weight', 1, current_day)
         ], dividechars=4, focus_column=0)
         new_pane.title = editor.title
+        new_pane.get_keys = editor.get_keys
 
         def teardown(data):
             self.editor = False
@@ -718,6 +719,11 @@ class EventEditor(urwid.WidgetWrap, Config):
     def title(self):  # Window title
         return 'Edit: {}'.format(self.summary.get_edit_text())
 
+    def get_keys(self):
+        return [(['arrows'], 'navigate through properties'),
+                (['enter'], 'edit property'),
+                (['esc'], 'abort')]
+
     @classmethod
     def selectable(cls):
         return True
@@ -863,10 +869,9 @@ class ClassicView(Pane):
             self.collection.delete(href, etag, account)
 
 
-def start_pane(pane, callback, header=''):
+def start_pane(pane, callback, program_info=''):
     """Open the user interface with the given initial pane."""
-    frame = Window(header=header,
-                   footer='arrows: navigate, enter: select, q: quit, ?: help')
+    frame = Window(footer=program_info + ' | q: quit, ?: help')
     frame.open(pane, callback)
     loop = urwid.MainLoop(frame, Window.PALETTE,
                           unhandled_input=frame.on_key_press,

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -496,6 +496,7 @@ class EventColumn(urwid.WidgetWrap):
         self.editor = False
         self.date = None
         self.eventcount = 0
+        self.current_event = None
 
         # TODO make this switch from pile to columns depending on terminal size
         self.events = EventList(eventcolumn=self)
@@ -506,6 +507,8 @@ class EventColumn(urwid.WidgetWrap):
         """Show events for the specified date."""
         self.date = date
         self.eventcount = self.events.update(date)
+        if self.current_event is not None:
+            self.view(self.current_event)
 
     def view(self, event):
         """
@@ -520,6 +523,7 @@ class EventColumn(urwid.WidgetWrap):
         self.container.contents.append(
             (EventDisplay(self.pane.conf, event, collection=self.pane.collection),
              self.container.options()))
+        self.current_event = event
 
     def edit(self, event):
         """create an EventEditor and display it

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -190,7 +190,6 @@ class DateCColumns(CColumns):
         if key in self.keys['view']:
             self._old_attr_map = self.contents[self.focus_position][0].get_attr_map()
             self._old_pos = old_pos
-            self.contents[self.focus_position][0].set_attr_map({None: 'today focus'})
             return 'right'
         elif self._old_attr_map:
             self.contents[self._old_pos][0].set_attr_map(self._old_attr_map)

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -721,7 +721,7 @@ class EventEditor(urwid.WidgetWrap):
 
     @property
     def title(self):  # Window title
-        return 'Edit: {}'.format(self.summary.get_edit_text())
+        return u'Edit: {}'.format(self.summary.get_edit_text())
 
     def get_keys(self):
         return [(['arrows'], 'navigate through properties'),

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -288,7 +288,6 @@ class Choice(urwid.PopUpLauncher):
                              lambda button: self.open_pop_up())
 
 
-
 class ChoiceList(urwid.WidgetWrap):
     signals = ['close']
 

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -22,6 +22,8 @@
 
 
 import urwid
+import threading
+import time
 
 
 class CColumns(urwid.Columns):
@@ -208,8 +210,16 @@ class Window(urwid.Frame):
     def alert(self, msg):
         self.update_header(alert=msg)
 
+        def target():
+            time.sleep(5)
+            self.update_header()
+
+        t = threading.Thread(target=target)
+        t.daemon = True
+        t.start()
+
     def update_header(self, alert=None):
-        pane_title = getattr(self.get_body(), 'title', None)
+        pane_title = getattr(self._get_current_pane(), 'title', None)
         text = []
 
         for part in (pane_title, alert):

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -251,3 +251,60 @@ class AlertDaemon(threading.Thread):
             except _exception:
                 pass
             _event.clear()
+
+
+class Choice(urwid.PopUpLauncher):
+    def __init__(self, choices, active, decorate_func=None):
+        self.choices = choices
+        self._decorate = decorate_func or (lambda x: x)
+        self.active = self._original = active
+
+    def create_pop_up(self):
+        pop_up = ChoiceList(self)
+        urwid.connect_signal(pop_up, 'close',
+                             lambda button: self.close_pop_up())
+        return pop_up
+
+    def get_pop_up_parameters(self):
+        return {'left': 0,
+                'top': 1,
+                'overlay_width': 32,
+                'overlay_height': len(self.choices)}
+
+    @property
+    def changed(self):
+        return self._active != self._original
+
+    @property
+    def active(self):
+        return self._active
+
+    @active.setter
+    def active(self, val):
+        self._active = val
+        self.button = urwid.Button(self._decorate(self._active))
+        urwid.PopUpLauncher.__init__(self, self.button)
+        urwid.connect_signal(self.button, 'click',
+                             lambda button: self.open_pop_up())
+
+
+
+class ChoiceList(urwid.WidgetWrap):
+    signals = ['close']
+
+    def __init__(self, parent):
+        self.parent = parent
+        buttons = []
+        for c in parent.choices:
+            buttons.append(
+                urwid.Button(parent._decorate(c),
+                             on_press=self.set_choice, user_data=c)
+            )
+
+        pile = CPile(buttons)
+        fill = urwid.Filler(pile)
+        urwid.WidgetWrap.__init__(self, urwid.AttrMap(fill, 'popupbg'))
+
+    def set_choice(self, button, account):
+        self.parent.active = account
+        self._emit("close")

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -200,7 +200,11 @@ class Window(urwid.Frame):
             self.open(HelpPane(self._get_current_pane()))
 
     def _update(self, pane):
-        self.header.w.set_text(u'%s | %s' % (self._title, pane.title))
+        title = pane.title
+        if self._title:
+            title += ' | '
+            title += self._title
+        self.header.w.set_text(title)
         self.set_body(pane)
 
     def _get_current_pane(self):

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -152,16 +152,15 @@ class Window(urwid.Frame):
                ('white', 'white', ''),
                ]
 
-    def __init__(self, header='', footer=''):
+    def __init__(self, footer=''):
         self._track = []
-        self._title = header
-        self._footer = footer
 
-        header = urwid.AttrWrap(urwid.Text(self._title), 'header')
-        footer = urwid.AttrWrap(urwid.Text(self._footer), 'footer')
+        header = urwid.AttrWrap(urwid.Text(''), 'header')
+        footer = urwid.AttrWrap(urwid.Text(footer), 'footer')
         urwid.Frame.__init__(self, urwid.Text(''),
                              header=header,
                              footer=footer)
+        self.update_header()
         self._original_w = None
 
     def open(self, pane, callback=None):
@@ -200,12 +199,22 @@ class Window(urwid.Frame):
             self.open(HelpPane(self._get_current_pane()))
 
     def _update(self, pane):
-        title = pane.title
-        if self._title:
-            title += ' | '
-            title += self._title
-        self.header.w.set_text(title)
         self.set_body(pane)
+        self.update_header()
 
     def _get_current_pane(self):
         return self._track[-1][0] if self._track else None
+
+    def alert(self, msg):
+        self.update_header(alert=msg)
+
+    def update_header(self, alert=None):
+        pane_title = getattr(self.get_body(), 'title', None)
+        text = []
+
+        for part in (pane_title, alert):
+            if part:
+                text.append(part)
+                text.append(('black', ' | '))
+
+        self.header.w.set_text(text[:-1] or '')

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -175,15 +175,6 @@ class Window(urwid.Frame):
         self._track.append((pane, callback))
         self._update(pane)
 
-    def overlay(self, overlay_w, title):
-        """put overlay_w as an overlay over the currently active pane
-        """
-        overlay = Pane(urwid.Overlay(urwid.Filler(overlay_w),
-                                     self._get_current_pane(),
-                                     'center', 60,
-                                     'middle', 5), title)
-        self.open(overlay)
-
     def backtrack(self, data=None):
         """Unstack the displayed pane.
 
@@ -192,7 +183,7 @@ class Window(urwid.Frame):
         this callback is called with the given data (if any) before
         the previous pane gets redrawn.
         """
-        _, cb = self._track.pop()
+        old_pane, cb = self._track.pop()
         if cb:
             cb(data)
 

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -126,8 +126,8 @@ class Window(urwid.Frame):
                ('button', 'black', 'dark cyan'),
                ('button focused', 'white', 'light blue', 'bold'),
                ('reveal focus', 'black', 'dark cyan', 'standout'),
-               ('today_focus', 'white', 'black', 'standout'),
-               ('today', 'black', 'white', 'dark cyan'),
+               ('today focus', 'white', 'dark cyan', 'standout'),
+               ('today', 'black', 'light gray', 'dark cyan'),
                ('edit', 'white', 'dark blue'),
                ('alert', 'white', 'dark red'),
 


### PR DESCRIPTION
This contains a few WIP changes to the UI. My goal is to make ikhal
behave like mutt: `q` or `esc` always brings the user back to the
previous screen. The event editor now has its own pane, as I felt that
the screen was getting too crowded.

Some internal classes have been revised, and some "convenience"
attributes have been removed.

Todo:

- [ ] Redesing the event editor
   - [x] introduce spacing at necessary places
   - [ ] somehow enable the user to save & exit without hitting
     down-arrow multiple times?
- [x] BUG: You can't edit events twice
- [ ] Don't re-scan calendars while saving
- [x] Don't allow editing for read-only calendars