### PR TITLE
Accept entries if RRULE has no TZDATA.

### DIFF
--- a/khal/khalendar/aux.py
+++ b/khal/khalendar/aux.py
@@ -69,7 +69,8 @@ def expand(vevent, default_tz, href=''):
             rrule._until = datetime(2037, 12, 31)
 
         if getattr(rrule._until, 'tzinfo', False):
-            rrule._until = rrule._until.astimezone(events_tz or default_tz)
+            if events_tz:
+                rrule._until = rrule._until.astimezone(events_tz or default_tz)
             rrule._until = rrule._until.replace(tzinfo=None)
 
         logger.debug('calculating recurrence dates for {0}, '


### PR DESCRIPTION
By simply adding `RRULE:FREQ=WEEKLY;UNTIL=20150626T220000Z` to an event, `khal` will show an exception and ignore the entry.

AFAIK, the above sample is actually valid, and is what, for example, thunderbird adds though here's a full entry (in case context is really important):

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//CALENDARSERVER.ORG//NONSGML Version 1//EN
BEGIN:VTIMEZONE
TZID:local
BEGIN:STANDARD
DTSTART;VALUE=DATE-TIME:20090314T230000
TZNAME:ART
TZOFFSETFROM:-0200
TZOFFSETTO:-0300
END:STANDARD
END:VTIMEZONE
BEGIN:VEVENT
SUMMARY:Análisis de Sistemas
RRULE:FREQ=WEEKLY;UNTIL=20150626T220000Z
DTSTART;TZID=local;VALUE=DATE-TIME:20150303T190000
DTEND;TZID=local;VALUE=DATE-TIME:20150303T220000
DTSTAMP;VALUE=DATE-TIME:20150313T084636Z
UID:GNS7M9KI4GMEOJ7BX70DFK44THMSA9GABJ3D
SEQUENCE:0
LOCATION:Aula 4-3\, Mario Bravo 1050
END:VEVENT
END:VCALENDAR
```

This PR avoids this crash by not passing `tz_event` if it's None. The patch does not and does not break any cases, though I'm not an expert on the ICS format, so I may have something wrong that I missed (I don't think I do though, since this is pretty much what thunderbird+lightning generates too).

Fixes #174. Yeah, sorry for the excesive noise.