### PR TITLE
Add a line about khal being in Fedora 22 onwards

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -5,6 +5,11 @@ If khal is packaged for your OS/distribution, using your system's
 standard package manager is probably the easiest way to install khal:
 
 - pkgsrc_
+- Fedora:
+  - Fedora 22 and later::
+  
+      sudo dnf install -y khal
+
 - Personal repos for openSUSE:
 
   - openSUSE 13.1::


### PR DESCRIPTION
khal will be present as an rpm in Fedora 22 and later.
Make a note of this in the install docs.