### PR TITLE
Show Organizer & Fix BST

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,3 +8,4 @@ Eric Scheibler - email [at] eric-scheibler [dot] de - http://eric-scheibler.de
 Pierre David - pdagog [at] gmail [dot] com
 Markus Unterwaditzer - markus [at] unterwaditzer [dot] net - https://unterwaditzer.net
 Hugo Osvaldo Barrera - hugo@barrera.io - https://hugo.barrera.io
+Bradley Jones - caffeinatedbrad [at] gmail [dot] com - http://caffeinatedbrad.com

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -401,6 +401,7 @@ def create_timezone(tz, first_date=None, last_date=None):
     timezone.add('TZID', tz)
 
     dst = {one[2]: 'DST' in two.__repr__() for one, two in iteritems(tz._tzinfos)}
+    bst = {one[2]: 'BST' in two.__repr__() for one, two in iteritems(tz._tzinfos)}
 
     # looking for the first and last transition time we need to include
     first_num, last_num = 0, len(tz._utc_transition_times) - 1
@@ -426,7 +427,7 @@ def create_timezone(tz, first_date=None, last_date=None):
                 timezones[name].add('RDATE', ttime)
             continue
 
-        if dst[name]:
+        if dst[name] or bst[name]:
             subcomp = icalendar.TimezoneDaylight()
         else:
             subcomp = icalendar.TimezoneStandard()

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -559,8 +559,16 @@ class EventDisplay(urwid.WidgetWrap):
 
         lines.append(divider)
 
+        # show organizer
+        try:
+            organizer = str(event.vevent['ORGANIZER'].encode('utf-8')).split(':')
+            lines.append(urwid.Text(
+                'Organizer: ' + organizer[len(organizer) - 1]))
+        except KeyError:
+            pass
+
         # description and location
-        for key, desc in [('DESCRIPTION', 'Description'), ('LOCATION', 'Location')]:
+        for key, desc in [('LOCATION', 'Location'), ('DESCRIPTION', 'Description')]:
             try:
                 lines.append(urwid.Text(
                     desc + ': ' + str(event.vevent[key].encode('utf-8'))))


### PR DESCRIPTION
If Organizer is present on an event show it, stripping out mailto: in the
string. Also move location before description as often descriptions are much
longer than the location.

Added check for BST for when timezone reports British Summer Time not DST