### PR TITLE
python3 compatibility

### DIFF
--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -24,7 +24,8 @@ from __future__ import print_function
 import calendar
 import datetime
 
-from .terminal import bstring, rstring
+from click import style
+
 from .compat import VERSION
 
 
@@ -63,7 +64,7 @@ def str_week(week, today):
     strweek = ''
     for day in week:
         if day == today:
-            day = rstring(str(day.day).rjust(2))
+            day = style(str(day.day).rjust(2), reverse=True)
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '
@@ -101,19 +102,23 @@ def vertical_month(month=datetime.date.today().month,
     w_number = '    ' if weeknumber == 'right' else ''
     calendar.setfirstweekday(firstweekday)
     _calendar = calendar.Calendar(firstweekday)
-    khal.append(bstring('    ' + calendar.weekheader(2) + ' ' + w_number))
+    khal.append(
+        style('    ' + calendar.weekheader(2) + ' ' + w_number, bold=True)
+    )
     for _ in range(count):
         for week in _calendar.monthdatescalendar(year, month):
             new_month = len([day for day in week if day.day == 1])
             strweek = str_week(week, today)
             if new_month:
-                m_name = bstring(month_abbr(week[6].month).ljust(4))
+                m_name = style(month_abbr(week[6].month).ljust(4), bold=True)
             elif weeknumber == 'left':
-                m_name = bstring(' {:2} '.format(getweeknumber(week[0])))
+                m_name = \
+                    style(' {:2} '.format(getweeknumber(week[0])), bold=True)
             else:
                 m_name = '    '
             if weeknumber == 'right':
-                w_number = bstring(' {}'.format(getweeknumber(week[0])))
+                w_number = \
+                    style(' {}'.format(getweeknumber(week[0])), bold=True)
             else:
                 w_number = ''
 

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -37,6 +37,7 @@ from khal import aux, controllers, khalendar, __version__
 from khal.log import logger
 from khal.settings import get_config, InvalidSettingsError
 from khal.exceptions import FatalError
+from .compat import to_unicode
 from .terminal import colored, get_terminal_size
 
 
@@ -144,7 +145,7 @@ def prepare_context(ctx, config, verbose):
         sys.exit(1)
 
     logger.debug('Using config:')
-    logger.debug(stringify_conf(conf).decode('utf-8'))
+    logger.debug(to_unicode(stringify_conf(conf), 'utf-8'))
 
     if conf is None:
         raise click.UsageError('Invalid config file, exiting.')

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -298,8 +298,10 @@ def _get_cli():
         for event in events:
             desc = textwrap.wrap(event.long(), term_width)
             event_column.extend([colored(d, event.color) for d in desc])
-        click.echo('\n'.join(event_column).encode(
-            ctx.obj['conf']['locale']['encoding']))
+        click.echo(to_unicode(
+            '\n'.join(event_column),
+            ctx.obj['conf']['locale']['encoding'])
+        )
 
     @cli.command()
     @calendar_selector
@@ -341,7 +343,10 @@ def _get_cli():
         for event in events:
             desc = textwrap.wrap(event.long(), term_width)
             event_column.extend([colored(d, event.color) for d in desc])
-        click.echo('\n'.join(event_column).encode(ctx.obj['conf']['locale']['encoding']))
+        click.echo(to_unicode(
+            '\n'.join(event_column),
+            ctx.obj['conf']['locale']['encoding'])
+        )
 
     return cli, interactive_cli
 

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -21,6 +21,8 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+from __future__ import unicode_literals
+
 from click import echo
 
 import datetime
@@ -50,9 +52,9 @@ def construct_daynames(daylist, longdateformat):
     """
     for date in daylist:
         if date == datetime.date.today():
-            yield (date, u'Today:')
+            yield (date, 'Today:')
         elif date == datetime.date.today() + datetime.timedelta(days=1):
-            yield (date, u'Tomorrow:')
+            yield (date, 'Tomorrow:')
         else:
             yield (date, date.strftime(longdateformat))
 
@@ -186,5 +188,5 @@ class Interactive(object):
                               description='do something')
         ui.start_pane(
             pane, pane.cleanup,
-            program_info=u'{0} v{1}'.format(__productname__, __version__)
+            program_info='{0} v{1}'.format(__productname__, __version__)
         )

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -32,6 +32,7 @@ import sys
 import textwrap
 
 from khal import aux, calendar_display
+from khal.compat import to_unicode
 from khal.khalendar.exceptions import ReadOnlyCalendarError
 from khal.exceptions import FatalError
 from khal.khalendar.event import Event
@@ -146,7 +147,7 @@ class Agenda(object):
         term_width, _ = get_terminal_size()
         event_column = get_agenda(collection, dates=date, width=term_width,
                                   show_all_days=show_all_days, **kwargs)
-        echo('\n'.join(event_column).encode(encoding))
+        echo(to_unicode('\n'.join(event_column), encoding))
 
 
 class NewFromString(object):

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -137,6 +137,8 @@ class Calendar(object):
             firstweekday=firstweekday, weeknumber=weeknumber)
 
         rows = merge_columns(calendar_column, event_column)
+        # XXX: Generate this as a unicode in the first place, rather than
+        # casting it.
         echo('\n'.join(rows).encode(encoding))
 
 
@@ -147,6 +149,8 @@ class Agenda(object):
         term_width, _ = get_terminal_size()
         event_column = get_agenda(collection, dates=date, width=term_width,
                                   show_all_days=show_all_days, **kwargs)
+        # XXX: Generate this as a unicode in the first place, rather than
+        # casting it.
         echo(to_unicode('\n'.join(event_column), encoding))
 
 

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -23,7 +23,7 @@
 
 from __future__ import unicode_literals
 
-from click import echo
+from click import echo, style
 
 import datetime
 import itertools
@@ -37,7 +37,7 @@ from khal.exceptions import FatalError
 from khal.khalendar.event import Event
 from khal import __version__, __productname__
 from khal.log import logger
-from .terminal import bstring, colored, get_terminal_size, merge_columns
+from .terminal import colored, get_terminal_size, merge_columns
 
 
 def construct_daynames(daylist, longdateformat):
@@ -111,14 +111,14 @@ def get_agenda(collection, locale, dates=None,
         if len(events) == 0 and len(all_day_events) == 0 and not show_all_days:
             continue
 
-        event_column.append(bstring(dayname))
+        event_column.append(style(dayname, bold=True))
         events.sort(key=lambda e: e.start)
         for event in itertools.chain(all_day_events, events):
             desc = textwrap.wrap(event.compact(day), width)
             event_column.extend([colored(d, event.color) for d in desc])
 
     if event_column == []:
-        event_column = [bstring('No events')]
+        event_column = [style('No events', bold=True)]
     return event_column
 
 
@@ -172,10 +172,10 @@ class NewFromString(object):
                          'read-only'.format(collection.default_calendar_name))
             sys.exit(1)
         if conf['default']['print_new'] == 'event':
-            print(event.long())
+            echo(event.long())
         elif conf['default']['print_new'] == 'path':
             path = collection._calnames[event.calendar].path + event.href
-            print(path.encode(conf['locale']['encoding']))
+            echo(path.encode(conf['locale']['encoding']))
 
 
 class Interactive(object):

--- a/khal/khalendar/aux.py
+++ b/khal/khalendar/aux.py
@@ -5,6 +5,7 @@ import dateutil.rrule
 import pytz
 
 from .. import log
+from ..compat import to_unicode
 
 from .exceptions import UnsupportedRecursion
 
@@ -58,7 +59,7 @@ def expand(vevent, default_tz, href=''):
         vevent['DTSTART'].dt = vevent['DTSTART'].dt.replace(tzinfo=None)
 
     if 'RRULE' in vevent:
-        rrulestr = vevent['RRULE'].to_ical()
+        rrulestr = to_unicode(vevent['RRULE'].to_ical())
         rrule = dateutil.rrule.rrulestr(rrulestr, dtstart=vevent['DTSTART'].dt)
 
         if not set(['UNTIL', 'COUNT']).intersection(vevent['RRULE'].keys()):

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -29,7 +29,7 @@ note on naming:
     respective types
 
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import contextlib
 import datetime
@@ -526,7 +526,7 @@ def check_support(vevent, href, calendar):
             .format(href, calendar)
         )
     rdate = vevent.get('RDATE')
-    if rdate is not None and rdate.params.get('VALUE') == u'PERIOD':
+    if rdate is not None and rdate.params.get('VALUE') == 'PERIOD':
         raise UpdateFailed(
             '`RDATE;VALUE=PERIOD` is currently not supported by khal. '
             'Therefore event {} from calendar {} will not be shown in khal.\n'
@@ -546,7 +546,7 @@ class SQLiteDb_Birthdays(SQLiteDb):
         if 'BDAY' in vcard.keys():
             bday = vcard['BDAY']
             try:
-                if bday[0:2] == u'--' and bday[3] != u'-':
+                if bday[0:2] == '--' and bday[3] != '-':
                     bday = '1900' + bday[2:]
                 bday = parser.parse(bday).date()
             except ValueError:
@@ -557,7 +557,7 @@ class SQLiteDb_Birthdays(SQLiteDb):
             event = icalendar.Event()
             event.add('dtstart', bday)
             event.add('dtend', bday + datetime.timedelta(days=1))
-            event.add('summary', u'{}\'s birthday'.format(name))
+            event.add('summary', '{}\'s birthday'.format(name))
             event.add('rrule', {'freq': 'YEARLY'})
             event.add('uid', href)
             self._update_impl(event, href, etag)

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -22,6 +22,8 @@
 
 """this module will the event model, hopefully soon in a cleaned up version"""
 
+from __future__ import unicode_literals
+
 from datetime import date, datetime, time, timedelta
 
 import icalendar
@@ -114,19 +116,19 @@ class Event(object):
     def symbol_strings(self):
         if self.unicode_symbols:
             return dict(
-                recurring=u'\N{Clockwise gapped circle arrow}',
-                range=u'\N{Left right arrow}',
-                range_end=u'\N{Rightwards arrow to bar}',
-                range_start=u'\N{Rightwards arrow from bar}',
-                right_arrow=u'\N{Rightwards arrow}'
+                recurring='\N{Clockwise gapped circle arrow}',
+                range='\N{Left right arrow}',
+                range_end='\N{Rightwards arrow to bar}',
+                range_start='\N{Rightwards arrow from bar}',
+                right_arrow='\N{Rightwards arrow}'
             )
         else:
             return dict(
-                recurring=u'R',
-                range=u'<->',
-                range_end=u'->|',
-                range_start=u'|->',
-                right_arrow=u'->'
+                recurring='R',
+                range='<->',
+                range_end='->|',
+                range_start='|->',
+                right_arrow='->'
             )
 
     @property
@@ -237,31 +239,31 @@ class Event(object):
                 else:
                     startstr = self.start.strftime(self.locale['longdateformat'])
                 endstr = end.strftime(self.locale['longdateformat'])
-                rangestr = startstr + u' - ' + endstr
+                rangestr = startstr + ' - ' + endstr
         else:
             # same day
             if self.start.utctimetuple()[:3] == self.end.utctimetuple()[:3]:
                 starttime = self.start.strftime(self.locale['timeformat'])
                 endtime = self.end.strftime(self.locale['timeformat'])
                 datestr = self.end.strftime(self.locale['longdateformat'])
-                rangestr = starttime + u'-' + endtime + u' ' + datestr
+                rangestr = starttime + '-' + endtime + ' ' + datestr
             else:
                 startstr = self.start.strftime(self.locale['longdatetimeformat'])
                 endstr = self.end.strftime(self.locale['longdatetimeformat'])
-                rangestr = startstr + u' - ' + endstr
+                rangestr = startstr + ' - ' + endstr
             if self.start.tzinfo.zone != self.locale['local_timezone'].zone:
                 # doesn't work yet
                 # TODO FIXME
                 pass
 
-        location = u'\nLocation: ' + self.location if \
-            self.location is not None else u''
-        description = u'\nDescription: ' + self.description if \
-            self.description is not None else u''
-        repitition = u'\nRepeat: ' + self.recurpattern if \
-            self.recurpattern is not None else u''
+        location = '\nLocation: ' + self.location if \
+            self.location is not None else ''
+        description = '\nDescription: ' + self.description if \
+            self.description is not None else ''
+        repitition = '\nRepeat: ' + self.recurpattern if \
+            self.recurpattern is not None else ''
 
-        return u'{}: {}{}{}{}'.format(
+        return '{}: {}{}{}{}'.format(
             rangestr, self.summary, location, repitition, description)
 
     def compact(self, day):

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -28,7 +28,7 @@ from datetime import date, datetime, time, timedelta
 
 import icalendar
 
-from ..compat import unicode_type, bytes_type, iteritems
+from ..compat import unicode_type, bytes_type, iteritems, to_unicode
 from .aux import to_naive_utc
 from ..log import logger
 
@@ -260,7 +260,7 @@ class Event(object):
             self.location is not None else ''
         description = '\nDescription: ' + self.description if \
             self.description is not None else ''
-        repitition = '\nRepeat: ' + self.recurpattern if \
+        repitition = '\nRepeat: ' + to_unicode(self.recurpattern) if \
             self.recurpattern is not None else ''
 
         return '{}: {}{}{}{}'.format(

--- a/khal/terminal.py
+++ b/khal/terminal.py
@@ -68,23 +68,6 @@ COLORS = {
 }
 
 
-def rstring(string):
-    """returns string as reverse color string (ANSI escape codes)
-
-    >>> rstring('test')
-    '\\x1b[7mtest\\x1b[0m'
-    """
-    return RTEXT + string + NTEXT
-
-
-def bstring(string):
-    """returns string as bold string (ANSI escape codes)
-    >>> bstring('test')
-    '\\x1b[1mtest\\x1b[0m'
-    """
-    return BTEXT + string + NTEXT
-
-
 def colored(string, colorstring):
     try:
         color = COLORS[colorstring]

--- a/khal/terminal.py
+++ b/khal/terminal.py
@@ -23,9 +23,9 @@
 """all functions related to terminal display are collected here"""
 
 try:
-    from itertools import izip_longest
+    from itertools import izip_longest as zip_longest
 except ImportError:
-    from itertools import zip_longest as izip_longest
+    from itertools import zip_longest
 
 try:
     # python 3.3+
@@ -107,6 +107,6 @@ def merge_columns(lcolumn, rcolumn, width=25):
     if missing > 0:
         lcolumn = lcolumn + missing * [width * ' ']
 
-    rows = ['    '.join(one) for one in izip_longest(
+    rows = ['    '.join(one) for one in zip_longest(
         lcolumn, rcolumn, fillvalue='')]
     return rows

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -20,6 +20,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+
 import calendar
 from datetime import date, datetime, time, timedelta
 import signal
@@ -554,7 +556,7 @@ class EventDisplay(urwid.WidgetWrap):
         lines = []
         lines.append(urwid.Columns([
             urwid.Text(event.vevent['SUMMARY']),
-            urwid.Text(u'Calendar: ' + event.calendar)
+            urwid.Text('Calendar: ' + event.calendar)
         ], dividechars=2))
 
         lines.append(divider)
@@ -600,8 +602,8 @@ class EventDisplay(urwid.WidgetWrap):
         if startstr == endstr:
             lines.append(urwid.Text('On: ' + startstr))
         else:
-            lines.append(urwid.Text(u'From: ' + startstr))
-            lines.append(urwid.Text(u'To: ' + endstr))
+            lines.append(urwid.Text('From: ' + startstr))
+            lines.append(urwid.Text('To: ' + endstr))
 
         pile = CPile(lines)
         urwid.WidgetWrap.__init__(self, urwid.Filler(pile, valign='top'))
@@ -629,11 +631,11 @@ class EventEditor(urwid.WidgetWrap):
         try:
             self.description = event.vevent['DESCRIPTION']
         except KeyError:
-            self.description = u''
+            self.description = ''
         try:
             self.location = event.vevent['LOCATION']
         except KeyError:
-            self.location = u''
+            self.location = ''
 
         if event.allday:
             end = event.end - timedelta(days=1)
@@ -661,9 +663,9 @@ class EventEditor(urwid.WidgetWrap):
             self.collection._calnames[self.event.calendar],
             decorate_choice
         )
-        self.description = Edit(caption=u'Description: ',
+        self.description = Edit(caption='Description: ',
                                 edit_text=self.description)
-        self.location = Edit(caption=u'Location: ',
+        self.location = Edit(caption='Location: ',
                              edit_text=self.location)
         self.pile = urwid.ListBox(CSimpleFocusListWalker([
             urwid.Columns([
@@ -677,14 +679,14 @@ class EventEditor(urwid.WidgetWrap):
             self.startendeditor,
             self.recursioneditor,
             divider,
-            urwid.Button(u'Save', on_press=self.save)
+            urwid.Button('Save', on_press=self.save)
         ]))
 
         urwid.WidgetWrap.__init__(self, self.pile)
 
     @property
     def title(self):  # Window title
-        return u'Edit: {}'.format(self.summary.get_edit_text())
+        return 'Edit: {}'.format(self.summary.get_edit_text())
 
     def get_keys(self):
         return [(['arrows'], 'navigate through properties'),
@@ -795,8 +797,8 @@ class ClassicView(Pane):
     on the right
     """
 
-    def __init__(self, collection, conf=None, title=u'',
-                 description=u''):
+    def __init__(self, collection, conf=None, title='',
+                 description=''):
         self.init = True
         # Will be set when opening the view inside a Window
         self.window = None

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -30,6 +30,7 @@ import sys
 import urwid
 
 from .. import aux
+from ..compat import to_unicode
 from ..calendar_display import getweeknumber
 
 from .base import Pane, Window, CColumns, CPile, CSimpleFocusListWalker, Choice
@@ -563,7 +564,7 @@ class EventDisplay(urwid.WidgetWrap):
 
         # show organizer
         try:
-            organizer = str(event.vevent['ORGANIZER'].encode('utf-8')).split(':')
+            organizer = to_unicode(event.vevent['ORGANIZER'], 'utf-8').split(':')
             lines.append(urwid.Text(
                 'Organizer: ' + organizer[len(organizer) - 1]))
         except KeyError:
@@ -573,7 +574,7 @@ class EventDisplay(urwid.WidgetWrap):
         for key, desc in [('LOCATION', 'Location'), ('DESCRIPTION', 'Description')]:
             try:
                 lines.append(urwid.Text(
-                    desc + ': ' + str(event.vevent[key].encode('utf-8'))))
+                    desc + ': ' + to_unicode(event.vevent[key], 'utf-8')))
             except KeyError:
                 pass
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 import pytest
 from click.testing import CliRunner
 
+from khal.compat import to_bytes
 from khal.cli import main_khal
 
 
@@ -186,7 +187,7 @@ def test_invalid_calendar(runner):
 def test_no_vevent(runner, tmpdir, contents):
     runner = runner(command='agenda', showalldays=False, days=2)
     broken_item = runner.calendars['one'].join('broken_item.ics')
-    broken_item.write(contents.encode('utf-8'), mode='wb')
+    broken_item.write(to_bytes(contents, 'utf-8'), mode='wb')
 
     result = runner.invoke(main_khal)
     assert not result.exception

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -78,7 +78,7 @@ def test_direct_modification(runner):
     event.write(cal_dt)
     result = runner.invoke(main_khal, ['agenda', '09.04.2014'])
     assert not result.exception
-    assert result.output == u'09.04.2014\n09:30-10:30: An Event\n'
+    assert result.output == '09.04.2014\n09:30-10:30: An Event\n'
 
     os.remove(str(event))
     result = runner.invoke(main_khal, ['agenda'])

--- a/tests/event_from_string_test.py
+++ b/tests/event_from_string_test.py
@@ -1,6 +1,5 @@
 # vim: set fileencoding=utf-8:
 from datetime import date, datetime, timedelta
-import random
 
 import pytz
 
@@ -31,6 +30,15 @@ kwargs_de = {
 def _create_testcases(*cases):
     return [(userinput, to_bytes('\r\n'.join(output) + '\r\n', 'utf-8'))
             for userinput, output in cases]
+
+
+def _replace_uid(event):
+    """
+    Replace an event's UID with E41JRQX2DB4P1AQZI86BAT7NHPBHPRIIHQKA.
+    """
+    event.pop('uid')
+    event.add('uid', 'E41JRQX2DB4P1AQZI86BAT7NHPBHPRIIHQKA')
+    return event
 
 
 test_set_format_de = _create_testcases(
@@ -125,11 +133,11 @@ test_set_format_de = _create_testcases(
 
 def test_construct_event_format_de():
     for data_list, vevent in test_set_format_de:
-        random.seed(1)
         event = construct_event(data_list.split(),
                                 _now=_now,
-                                **kwargs_de).to_ical()
-        assert event == vevent
+                                **kwargs_de)
+
+        assert _replace_uid(event).to_ical() == vevent
 
 
 test_set_format_us = _create_testcases(
@@ -162,11 +170,10 @@ def test_construct_event_format_us():
         'default_timezone': pytz.timezone('America/New_York'),
     }
     for data_list, vevent in test_set_format_us:
-        random.seed(1)
         event = construct_event(data_list.split(),
                                 _now=_now,
-                                **kwargs).to_ical()
-        assert event == vevent
+                                **kwargs)
+        assert _replace_uid(event).to_ical() == vevent
 
 
 test_set_format_de_complexer = _create_testcases(
@@ -202,11 +209,10 @@ test_set_format_de_complexer = _create_testcases(
 
 def test_construct_event_format_de_complexer():
     for data_list, vevent in test_set_format_de_complexer:
-        random.seed(1)
         event = construct_event(data_list.split(),
                                 _now=_now,
-                                **kwargs_de).to_ical()
-        assert event == vevent
+                                **kwargs_de)
+        assert _replace_uid(event).to_ical() == vevent
 
 
 test_set_description = _create_testcases(
@@ -245,11 +251,10 @@ test_set_description = _create_testcases(
 
 def test_description():
     for data_list, vevent in test_set_description:
-        random.seed(1)
         event = construct_event(data_list.split(),
                                 _now=_now,
-                                **kwargs_de).to_ical()
-        assert event == vevent
+                                **kwargs_de)
+        assert _replace_uid(event).to_ical() == vevent
 
 test_set_repeat = _create_testcases(
     # now events where the start date has to be inferred, too
@@ -268,13 +273,12 @@ test_set_repeat = _create_testcases(
 
 def test_repeat():
     for data_list, vevent in test_set_repeat:
-        random.seed(1)
         event = construct_event(data_list.split(),
                                 description='please describe the event',
                                 repeat='daily',
                                 _now=_now,
-                                **kwargs_de).to_ical()
-        assert event == vevent
+                                **kwargs_de)
+        assert _replace_uid(event).to_ical() == vevent
 
 
 test_set_description_and_location = _create_testcases(
@@ -294,10 +298,9 @@ test_set_description_and_location = _create_testcases(
 
 def test_description_and_location():
     for data_list, vevent in test_set_description_and_location:
-        random.seed(1)
         event = construct_event(data_list.split(),
                                 description='please describe the event',
                                 _now=_now,
                                 location='in the office',
-                                **kwargs_de).to_ical()
-        assert event == vevent
+                                **kwargs_de)
+        assert _replace_uid(event).to_ical() == vevent

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -2,17 +2,7 @@
 # vim: set ts=4 sw=4 expandtab sts=4:
 
 
-from khal.terminal import merge_columns, colored, bstring, rstring
-
-
-def test_rstring():
-    assert rstring('test') == '\x1b[7mtest\x1b[0m'
-    assert rstring(u'täst') == u'\x1b[7mtäst\x1b[0m'
-
-
-def test_bstring():
-    assert bstring('test') == '\x1b[1mtest\x1b[0m'
-    assert bstring(u'täst') == u'\x1b[1mtäst\x1b[0m'
+from khal.terminal import merge_columns, colored
 
 
 def test_colored():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy
+envlist = py27, pypy, py34
 
 [testenv]
 deps = 


### PR DESCRIPTION
~~**Do not merge yet**~~ Update: This PR is ready for merging. See below for further details.

This is a work-in-progress PR, mostly to avoid anybody else duplicating the effort, and to get some preliminary feedback.

`khal` and `ikhal` work flawlessly. There are still nine tests failing, *however*, I'm inclined to think that it's due to how the tests are written rather than the code itself.

There's two types of failing tests with the tests right now:

 * Comparisons where the generated UID does not match the expected one. I haven't looked deeply into this yet.
 * Comparisons where python3 seems to be including shell escape code for bold, hence, outputs do not match: '\x1b[1mNo events\x1b[0m\n' == 'No events\n'. Fixing the test would break the python2 version, so I'll have to think of a better solution later on.