### PR TITLE
Add space and backspace as aliases for keybindings

### DIFF
--- a/doc/source/configspec.rst
+++ b/doc/source/configspec.rst
@@ -209,7 +209,7 @@ keybindings for `ikhal` are set here. You can bind more than one key
     move the cursor right (in the calendar browser)
 
       :type: list
-      :default: right, l
+      :default: right, l, space
 
 .. _keybindings-view:
 
@@ -259,7 +259,7 @@ keybindings for `ikhal` are set here. You can bind more than one key
     move the cursor left (in the calendar browser)
 
       :type: list
-      :default: left, h
+      :default: left, h, backspace
 
 .. _keybindings-today:
 

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -88,10 +88,10 @@ up = force_list(default=list('up', 'k'))
 down = force_list(default=list('down', 'j'))
 
 # move the cursor right (in the calendar browser)
-right = force_list(default=list('right', 'l'))
+right = force_list(default=list('right', 'l', ' '))
 
 # move the cursor left (in the calendar browser)
-left = force_list(default=list('left', 'h'))
+left = force_list(default=list('left', 'h', 'backspace'))
 
 # create a new event on the selected date
 new = force_list(default=list('n'))

--- a/tests/ui/test_calendarwidget.py
+++ b/tests/ui/test_calendarwidget.py
@@ -7,9 +7,9 @@ on_press = {}
 
 keybindings = {
     'today': ['T'],
-    'left': ['left', 'h'],
+    'left': ['left', 'h', 'backspace'],
     'up': ['up', 'k'],
-    'right': ['right', 'l'],
+    'right': ['right', 'l', ' '],
     'down': ['down', 'j'],
 }
 


### PR DESCRIPTION
As with vi, space is an alias for 'k' and backspace is an alias for 'h'.