### PR TITLE
Fix package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     'python-dateutil',
     'configobj',
     'tzlocal>=1.0',
+    'sqlite3',
 ]
 
 extra_requirements = {


### PR DESCRIPTION
I have noticed that the package actually depends on sqlite3 python module. When sqlite3 isn't installed, it dies saying it needs sqlite3:
```
% khal
Traceback (most recent call last):
  File "/usr/local/bin/khal", line 9, in <module>
    load_entry_point('khal==0.4.0', 'console_scripts', 'khal')()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 552, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2672, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2345, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2351, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/site-packages/khal/cli.py", line 33, in <module>
    from khal import controllers
  File "/usr/local/lib/python2.7/site-packages/khal/controllers.py", line 33, in <module>
    from khal.khalendar.exceptions import ReadOnlyCalendarError
  File "/usr/local/lib/python2.7/site-packages/khal/khalendar/__init__.py", line 23, in <module>
    from .khalendar import Calendar, CalendarCollection  # flake8: noqa
  File "/usr/local/lib/python2.7/site-packages/khal/khalendar/khalendar.py", line 37, in <module>
    from . import backend
  File "/usr/local/lib/python2.7/site-packages/khal/khalendar/backend.py", line 37, in <module>
    import sqlite3
  File "/usr/local/lib/python2.7/sqlite3/__init__.py", line 24, in <module>
    from dbapi2 import *
  File "/usr/local/lib/python2.7/sqlite3/dbapi2.py", line 28, in <module>
    from _sqlite3 import *
ImportError: No module named _sqlite3
```
This patch fixes this behavior.