### PR TITLE
[WIP] Use six instead of our own `compat` module.

### DIFF
--- a/khal/aux.py
+++ b/khal/aux.py
@@ -23,8 +23,6 @@
 """this module contains some helper functions converting strings or list of
 strings to date(time) or event objects"""
 
-from .compat import to_unicode
-
 from datetime import date, datetime, timedelta
 from datetime import time as dtime
 import random
@@ -283,7 +281,7 @@ def construct_event(dtime_list, locale,
             dtend = locale['default_timezone'].localize(dtend)
 
     event = icalendar.Event()
-    text = to_unicode(' '.join(dtime_list), encoding)
+    text = ' '.join(dtime_list)
     if not description or not location:
         summary = text.split(' :: ', 1)[0]
         try:

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -24,19 +24,14 @@ from __future__ import print_function
 import calendar
 import datetime
 
+import six
 from click import style
-
-from .compat import VERSION
 
 
 def month_abbr(month_no):
     """calendar.month_abbr[] are str (text) in python3 and str (bytes) in
     python2 """
-    if VERSION == 2:
-        # TODO check if how they are really encoded
-        return calendar.month_abbr[month_no].decode('utf-8')
-    elif VERSION == 3:
-        return calendar.month_abbr[month_no]
+    return six.u(calendar.month_abbr[month_no])
 
 
 def getweeknumber(date):

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -32,12 +32,12 @@ except ImportError:
 
 import click
 import pytz
+import six
 
 from khal import aux, controllers, khalendar, __version__
 from khal.log import logger
 from khal.settings import get_config, InvalidSettingsError
 from khal.exceptions import FatalError
-from .compat import to_unicode
 from .terminal import colored, get_terminal_size
 
 
@@ -169,7 +169,7 @@ def prepare_context(ctx, config, verbose):
 
     logger.debug('khal %s' % __version__)
     logger.debug('Using config:')
-    logger.debug(to_unicode(stringify_conf(conf), 'utf-8'))
+    logger.debug(six.u(stringify_conf(conf)))
 
     if conf is None:
         raise click.UsageError('Invalid config file, exiting.')
@@ -356,10 +356,7 @@ def _get_cli():
         for event in events:
             desc = textwrap.wrap(event.event_description, term_width)
             event_column.extend([colored(d, event.color) for d in desc])
-        click.echo(to_unicode(
-            '\n'.join(event_column),
-            ctx.obj['conf']['locale']['encoding'])
-        )
+        click.echo(six.u('\n'.join(event_column)))
 
     @cli.command()
     @multi_calendar_option
@@ -398,10 +395,7 @@ def _get_cli():
         for event in events:
             desc = textwrap.wrap(event.event_description, term_width)
             event_column.extend([colored(d, event.color) for d in desc])
-        click.echo(to_unicode(
-            '\n'.join(event_column),
-            ctx.obj['conf']['locale']['encoding'])
-        )
+        click.echo(six.u('\n'.join(event_column)))
 
     return cli, interactive_cli
 

--- a/khal/compat.py
+++ b/khal/compat.py
@@ -20,7 +20,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import sys
+import six
 
 
 def to_unicode(string, *args, **kwargs):
@@ -35,19 +35,5 @@ def to_bytes(string, *args, **kwargs):
     return string
 
 
-if sys.version_info[0] == 2:  # pragma: nocover
-    VERSION = 2
-    unicode_type = unicode  # NOQA
-    bytes_type = str
-    to_native = to_bytes
-
-    def iteritems(d, *args, **kwargs):
-        return iter(d.iteritems(*args, **kwargs))
-else:  # pragma: nocover
-    VERSION = 3
-    unicode_type = str
-    bytes_type = bytes
-    to_native = to_unicode
-
-    def iteritems(d, *args, **kwargs):
-        return iter(d.items(*args, **kwargs))
+unicode_type = six.text_type
+bytes_type = six.binary_type

--- a/khal/compat.py
+++ b/khal/compat.py
@@ -34,6 +34,5 @@ def to_bytes(string, *args, **kwargs):
         return string.encode(*args, **kwargs)
     return string
 
-
 unicode_type = six.text_type
 bytes_type = six.binary_type

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -36,7 +36,6 @@ import sys
 import textwrap
 
 from khal import aux, calendar_display
-from khal.compat import to_unicode
 from khal.khalendar.exceptions import ReadOnlyCalendarError, DuplicateUid
 from khal.exceptions import InvalidDate, FatalError
 from khal.khalendar.event import Event
@@ -155,7 +154,7 @@ def agenda(collection, date=None, encoding='utf-8',
                               show_all_days=show_all_days, **kwargs)
     # XXX: Generate this as a unicode in the first place, rather than
     # casting it.
-    echo(to_unicode('\n'.join(event_column), encoding))
+    echo('\n'.join(event_column))
 
 
 def new_from_string(collection, calendar_name, conf, date_list, location=None, repeat=None,

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -27,9 +27,8 @@ from __future__ import unicode_literals
 from datetime import date, datetime, time, timedelta
 
 import icalendar
-
-from ..compat import to_unicode
 from six import iteritems
+
 from .aux import to_naive_utc, to_unix_time, invalid_timezone
 from ..log import logger
 
@@ -388,7 +387,7 @@ class Event(object):
         location = '\nLocation: ' + self.location if self.location != '' else ''
         description = '\nDescription: ' + self.description if \
             self.description != '' else ''
-        repitition = '\nRepeat: ' + to_unicode(self.recurpattern) if \
+        repitition = '\nRepeat: ' + self.recurpattern if \
             self.recurpattern != '' else ''
 
         return '{}: {}{}{}{}'.format(

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -28,7 +28,8 @@ from datetime import date, datetime, time, timedelta
 
 import icalendar
 
-from ..compat import iteritems, to_unicode
+from ..compat import to_unicode
+from six import iteritems
 from .aux import to_naive_utc, to_unix_time, invalid_timezone
 from ..log import logger
 

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -24,8 +24,7 @@ from datetime import date, datetime, timedelta
 import re
 
 import urwid
-
-from ..compat import to_unicode
+import six
 
 
 class DateConversionError(Exception):
@@ -86,30 +85,30 @@ class ExtendedEdit(urwid.Edit):
 
     def _delete_word(self):
         """delete word before cursor"""
-        text = to_unicode(self.get_edit_text(), 'utf-8')
+        text = six.u(self.get_edit_text())
         f_text = delete_last_word(text[:self.edit_pos])
         self.set_edit_text(f_text + text[self.edit_pos:])
         self.set_edit_pos(len(f_text))
 
     def _delete_till_beginning_of_line(self):
         """delete till start of line before cursor"""
-        text = to_unicode(self.get_edit_text(), 'utf-8')
+        text = six.u(self.get_edit_text())
         f_text = delete_till_beginning_of_line(text[:self.edit_pos])
         self.set_edit_text(f_text + text[self.edit_pos:])
         self.set_edit_pos(len(f_text))
 
     def _delete_till_end_of_line(self):
         """delete till end of line before cursor"""
-        text = to_unicode(self.get_edit_text(), 'utf-8')
+        text = six.u(self.get_edit_text())
         f_text = delete_till_end_of_line(text[self.edit_pos:])
         self.set_edit_text(text[:self.edit_pos] + f_text)
 
     def _goto_beginning_of_line(self):
-        text = to_unicode(self.get_edit_text(), 'utf-8')
+        text = six.u(self.get_edit_text())
         self.set_edit_pos(goto_beginning_of_line(text[:self.edit_pos]))
 
     def _goto_end_of_line(self):
-        text = to_unicode(self.get_edit_text(), 'utf-8')
+        text = six.u(self.get_edit_text())
         self.set_edit_pos(goto_end_of_line(text[self.edit_pos:]) + self.edit_pos)
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     'python-dateutil',
     'configobj',
     'tzlocal>=1.0',
+    'six',
 ]
 
 extra_requirements = {

--- a/tests/aux_test.py
+++ b/tests/aux_test.py
@@ -36,7 +36,7 @@ locale_de = {
 
 
 def _create_testcases(*cases):
-    return [(userinput, to_bytes('\r\n'.join(output) + '\r\n', 'utf-8'))
+    return [(userinput, to_bytes('\r\n'.join(output) + '\r\n'))
             for userinput, output in cases]
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 import pytest
 from click.testing import CliRunner
 
-from khal.compat import to_bytes
 from khal.cli import main_khal
 
 from .aux import _get_text
@@ -216,7 +215,7 @@ def test_invalid_calendar(runner):
 def test_no_vevent(runner, tmpdir, contents):
     runner = runner(command='agenda', showalldays=False, days=2)
     broken_item = runner.calendars['one'].join('broken_item.ics')
-    broken_item.write(to_bytes(contents), mode='wb')
+    broken_item.write(contents, mode='w')
 
     result = runner.invoke(main_khal)
     assert not result.exception

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -216,7 +216,7 @@ def test_invalid_calendar(runner):
 def test_no_vevent(runner, tmpdir, contents):
     runner = runner(command='agenda', showalldays=False, days=2)
     broken_item = runner.calendars['one'].join('broken_item.ics')
-    broken_item.write(to_bytes(contents, 'utf-8'), mode='wb')
+    broken_item.write(to_bytes(contents), mode='wb')
 
     result = runner.invoke(main_khal)
     assert not result.exception


### PR DESCRIPTION
Using [six](https://pythonhosted.org/six/) has a few advantages:

 * Less code to maintain. Less is more.
 * More thoroughly tested compatibility code.
 * A few more things that we can make use of to maintain python2-compatibility (or py3-compat, depending on what you're using).
 * I *think* we can use this for #256, though I've failed so far.

This is tagged WIP, since I still need to get rid of a single usage of `to_unicode` and `to_bytes` that I haven't managed to get my head around. I'd also like to hear some opinions on this change.
