### PR TITLE
Implement #89 for khal

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,3 +12,4 @@ Bradley Jones - caffeinatedbrad [at] gmail [dot] com - http://caffeinatedbrad.co
 Micah Nordland - micah [at] rehack [dot] me - https://w3.thoughtfuldragon.com/
 Thomas Glanzmann - thomas [at] glanzmann [dot] de - https://thomas.glanzmann.de/
 John Shea - coachshea [at] fastmail [dot] com
+Dominik Joe Pantůček - joe [at] joe [dot] cz - http://joe.cz/

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -92,9 +92,9 @@ def str_highlight_day(day, devents, hmethod, default_color, multiple, color):
     return dstr
 
 
-def str_week(week, today, collection,
-             hmethod, default_color, multiple, color,
-             highlight_event_days, locale):
+def str_week(week, today, collection=None,
+             hmethod=None, default_color=None, multiple=None, color=None,
+             highlight_event_days=0, locale=None):
     """returns a string representing one week,
     if for day == today colour is reversed
 
@@ -107,16 +107,19 @@ def str_week(week, today, collection,
     :rtype: str
     """
     strweek = ''
-    localize = locale['local_timezone'].localize
     for day in week:
-        start = localize(datetime.datetime.combine(day, datetime.time.min))
-        end = localize(datetime.datetime.combine(day, datetime.time.max))
-        devents = collection.get_datetime_by_time_range(start, end) + collection.get_allday_by_time_range(day)
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
-        elif len(devents) > 0 and highlight_event_days != 0:
-            day = str_highlight_day(day, devents, hmethod, default_color,
-                                    multiple, color)
+        elif highlight_event_days != 0:
+            localize = locale['local_timezone'].localize
+            start = localize(datetime.datetime.combine(day, datetime.time.min))
+            end = localize(datetime.datetime.combine(day, datetime.time.max))
+            devents = collection.get_datetime_by_time_range(start, end) + collection.get_allday_by_time_range(day)
+            if len(devents) > 0:
+                day = str_highlight_day(day, devents, hmethod, default_color,
+                                        multiple, color)
+            else:
+                day = str(day.day).rjust(2)
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -70,8 +70,12 @@ def str_week(week, today, collection=None, conf=None):
             day = style(str(day.day).rjust(2), reverse=True)
         elif len(devents)>0 and conf['default']['highlight_event_days']!=0:
             dstr = str(day.day).rjust(2)
-            hmethod=conf['highlight_days']['method']
-            dcolor=urwid_to_click(devents[0].color)
+            hconf = conf['highlight_days']
+            hmethod = hconf['method']
+            if hconf['color']=='':
+                dcolor = urwid_to_click(devents[0].color)
+            else:
+                dcolor = urwid_to_click(hconf['color'])
             if hmethod=="foreground" or hmethod=="fg":
                 day = style(dstr, fg=dcolor)
             else:

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -49,7 +49,7 @@ def getweeknumber(date):
     return datetime.date.isocalendar(date)[1]
 
 
-def str_week(week, today, collection=None):
+def str_week(week, today, collection=None, conf=None):
     """returns a string representing one week,
     if for day == today colour is reversed
 
@@ -66,7 +66,7 @@ def str_week(week, today, collection=None):
         devents = collection.get_events_at(day)
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
-        elif len(devents)>0:
+        elif len(devents)>0 and conf['default']['highlight_event_days']!=0:
             colors = devents[0].color.split()
             color = colors[len(colors)-1]
             day = style(str(day.day).rjust(2), fg=color)
@@ -82,7 +82,8 @@ def vertical_month(month=datetime.date.today().month,
                    weeknumber=False,
                    count=3,
                    firstweekday=0,
-                   collection=None):
+                   collection=None,
+                   conf=None):
     """
     returns a list() of str() of weeks for a vertical arranged calendar
 
@@ -114,7 +115,7 @@ def vertical_month(month=datetime.date.today().month,
     for _ in range(count):
         for week in _calendar.monthdatescalendar(year, month):
             new_month = len([day for day in week if day.day == 1])
-            strweek = str_week(week, today, collection)
+            strweek = str_week(week, today, collection, conf)
             if new_month:
                 m_name = style(month_abbr(week[6].month).ljust(4), bold=True)
             elif weeknumber == 'left':

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -26,6 +26,8 @@ import datetime
 
 from click import style
 
+from terminal import urwid_to_click
+
 from .compat import VERSION
 
 
@@ -67,9 +69,13 @@ def str_week(week, today, collection=None, conf=None):
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
         elif len(devents)>0 and conf['default']['highlight_event_days']!=0:
-            colors = devents[0].color.split()
-            color = colors[len(colors)-1]
-            day = style(str(day.day).rjust(2), fg=color)
+            dstr = str(day.day).rjust(2)
+            hmethod=conf['highlight_days']['method']
+            dcolor=urwid_to_click(devents[0].color)
+            if hmethod=="foreground" or hmethod=="fg":
+                day = style(dstr, fg=dcolor)
+            else:
+                day = style(dstr, bg=dcolor)
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -130,7 +130,12 @@ def vertical_month(month=datetime.date.today().month,
                    count=3,
                    firstweekday=0,
                    collection=None,
-                   conf=None):
+                   hmethod='fg',
+                   default_color='',
+                   multiple='',
+                   color='',
+                   highlight_event_days=0,
+                   locale=None):
     """
     returns a list() of str() of weeks for a vertical arranged calendar
 
@@ -162,12 +167,8 @@ def vertical_month(month=datetime.date.today().month,
     for _ in range(count):
         for week in _calendar.monthdatescalendar(year, month):
             new_month = len([day for day in week if day.day == 1])
-            hconf = conf['highlight_days']
-            strweek = str_week(week, today, collection,
-                               hconf['method'], hconf['default_color'],
-                               hconf['multiple'], hconf['color'],
-                               conf['default']['highlight_event_days'],
-                               conf['locale'])
+            strweek = str_week(week, today, collection, hmethod, default_color,
+                               multiple, color, highlight_event_days, locale)
             if new_month:
                 m_name = style(month_abbr(week[6].month).ljust(4), bold=True)
             elif weeknumber == 'left':

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -54,7 +54,7 @@ def getweeknumber(date):
 def get_event_color(event, default_color):
     """Because multi-line lambdas would be un-Pythonic
     """
-    if event.color=='':
+    if event.color == '':
         return default_color
     return event.color
 
@@ -64,29 +64,29 @@ def str_highlight_day(day, devents, hconf):
     """
     dstr = str(day.day).rjust(2)
     hmethod = hconf['method']
-    if hconf['color']=='':
+    if hconf['color'] == '':
         dcolors = list(set(map(lambda x: get_event_color(x, hconf['default_color']), devents)))
-        if len(dcolors)>1:
-            if hconf['multiple']=='':
+        if len(dcolors) > 1:
+            if hconf['multiple'] == '':
                 color1 = urwid_to_click(dcolors[0])
                 color2 = urwid_to_click(dcolors[1])
-                if hmethod=="foreground" or hmethod=="fg":
-                    return style(dstr[:1], fg=color1)+style(dstr[1:], fg=color2)
+                if hmethod == "foreground" or hmethod == "fg":
+                    return style(dstr[:1], fg=color1) + style(dstr[1:], fg=color2)
                 else:
-                    return style(dstr[:1], bg=color1)+style(dstr[1:], bg=color2)
+                    return style(dstr[:1], bg=color1) + style(dstr[1:], bg=color2)
             else:
                 dcolor = urwid_to_click(hconf['multiple'])
         else:
-            if devents[0].color=='':
+            if devents[0].color == '':
                 dcolorv = hconf['default_color']
-                if dcolorv!='':
+                if dcolorv != '':
                     dcolor = urwid_to_click(dcolorv)
             else:
                 dcolor = urwid_to_click(devents[0].color)
     else:
         dcolor = urwid_to_click(hconf['color'])
-    if dcolor!='':
-        if hmethod=="foreground" or hmethod=="fg":
+    if dcolor != '':
+        if hmethod == "foreground" or hmethod == "fg":
             return style(dstr, fg=dcolor)
         else:
             return style(dstr, bg=dcolor)
@@ -111,10 +111,10 @@ def str_week(week, today, collection=None, conf=None):
     for day in week:
         start = localize(datetime.datetime.combine(day, datetime.time.min))
         end = localize(datetime.datetime.combine(day, datetime.time.max))
-        devents = collection.get_datetime_by_time_range(start,end)+collection.get_allday_by_time_range(day)
+        devents = collection.get_datetime_by_time_range(start, end) + collection.get_allday_by_time_range(day)
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
-        elif len(devents)>0 and conf['default']['highlight_event_days']!=0:
+        elif len(devents) > 0 and conf['default']['highlight_event_days'] != 0:
             day = str_highlight_day(day, devents, conf['highlight_days'])
         else:
             day = str(day.day).rjust(2)

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -114,7 +114,8 @@ def str_week(week, today, collection=None,
             localize = locale['local_timezone'].localize
             start = localize(datetime.datetime.combine(day, datetime.time.min))
             end = localize(datetime.datetime.combine(day, datetime.time.max))
-            devents = collection.get_datetime_by_time_range(start, end) + collection.get_allday_by_time_range(day)
+            devents = collection.get_datetime_by_time_range(start, end) + \
+                      collection.get_allday_by_time_range(day)
             if len(devents) > 0:
                 day = str_highlight_day(day, devents, hmethod, default_color,
                                         multiple, color)

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -94,7 +94,7 @@ def str_highlight_day(day, devents, hmethod, default_color, multiple, color):
 
 def str_week(week, today, collection=None,
              hmethod=None, default_color=None, multiple=None, color=None,
-             highlight_event_days=0, locale=None):
+             highlight_event_days=False, locale=None):
     """returns a string representing one week,
     if for day == today colour is reversed
 
@@ -110,7 +110,7 @@ def str_week(week, today, collection=None,
     for day in week:
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
-        elif highlight_event_days != 0:
+        elif highlight_event_days:
             localize = locale['local_timezone'].localize
             start = localize(datetime.datetime.combine(day, datetime.time.min))
             end = localize(datetime.datetime.combine(day, datetime.time.max))
@@ -137,7 +137,7 @@ def vertical_month(month=datetime.date.today().month,
                    default_color='',
                    multiple='',
                    color='',
-                   highlight_event_days=0,
+                   highlight_event_days=False,
                    locale=None):
     """
     returns a list() of str() of weeks for a vertical arranged calendar

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -92,7 +92,9 @@ def str_highlight_day(day, devents, hmethod, default_color, multiple, color):
     return dstr
 
 
-def str_week(week, today, collection=None, conf=None):
+def str_week(week, today, collection,
+             hmethod, default_color, multiple, color,
+             highlight_event_days, locale):
     """returns a string representing one week,
     if for day == today colour is reversed
 
@@ -105,7 +107,6 @@ def str_week(week, today, collection=None, conf=None):
     :rtype: str
     """
     strweek = ''
-    locale = conf['locale']
     localize = locale['local_timezone'].localize
     for day in week:
         start = localize(datetime.datetime.combine(day, datetime.time.min))
@@ -113,11 +114,9 @@ def str_week(week, today, collection=None, conf=None):
         devents = collection.get_datetime_by_time_range(start, end) + collection.get_allday_by_time_range(day)
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
-        elif len(devents) > 0 and conf['default']['highlight_event_days'] != 0:
-            hconf = conf['highlight_days']
-            day = str_highlight_day(day, devents, hconf['method'],
-                                    hconf['default_color'], hconf['multiple'],
-                                    hconf['color'])
+        elif len(devents) > 0 and highlight_event_days != 0:
+            day = str_highlight_day(day, devents, hmethod, default_color,
+                                    multiple, color)
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '
@@ -163,7 +162,12 @@ def vertical_month(month=datetime.date.today().month,
     for _ in range(count):
         for week in _calendar.monthdatescalendar(year, month):
             new_month = len([day for day in week if day.day == 1])
-            strweek = str_week(week, today, collection, conf)
+            hconf = conf['highlight_days']
+            strweek = str_week(week, today, collection,
+                               hconf['method'], hconf['default_color'],
+                               hconf['multiple'], hconf['color'],
+                               conf['default']['highlight_event_days'],
+                               conf['locale'])
             if new_month:
                 m_name = style(month_abbr(week[6].month).ljust(4), bold=True)
             elif weeknumber == 'left':

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -49,7 +49,7 @@ def getweeknumber(date):
     return datetime.date.isocalendar(date)[1]
 
 
-def str_week(week, today):
+def str_week(week, today, collection=None):
     """returns a string representing one week,
     if for day == today colour is reversed
 
@@ -65,6 +65,8 @@ def str_week(week, today):
     for day in week:
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
+        elif len(collection.get_events_at(day))>0:
+            day = style(str(day.day).rjust(2), bg='green', fg='black')
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '
@@ -76,7 +78,8 @@ def vertical_month(month=datetime.date.today().month,
                    today=datetime.date.today(),
                    weeknumber=False,
                    count=3,
-                   firstweekday=0):
+                   firstweekday=0,
+                   collection=None):
     """
     returns a list() of str() of weeks for a vertical arranged calendar
 
@@ -108,7 +111,7 @@ def vertical_month(month=datetime.date.today().month,
     for _ in range(count):
         for week in _calendar.monthdatescalendar(year, month):
             new_month = len([day for day in week if day.day == 1])
-            strweek = str_week(week, today)
+            strweek = str_week(week, today, collection)
             if new_month:
                 m_name = style(month_abbr(week[6].month).ljust(4), bold=True)
             elif weeknumber == 'left':

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -63,10 +63,13 @@ def str_week(week, today, collection=None):
     """
     strweek = ''
     for day in week:
+        devents = collection.get_events_at(day)
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
-        elif len(collection.get_events_at(day))>0:
-            day = style(str(day.day).rjust(2), bg='green', fg='black')
+        elif len(devents)>0:
+            colors = devents[0].color.split()
+            color = colors[len(colors)-1]
+            day = style(str(day.day).rjust(2), bg=color, fg='black')
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -71,7 +71,7 @@ def str_highlight_day(day, devents, hconf):
                 color1 = urwid_to_click(dcolors[0])
                 color2 = urwid_to_click(dcolors[1])
                 if hmethod=="foreground" or hmethod=="fg":
-                    return style(dstr[0:0], fg=color1)+style(dstr[1:1], fg=color2)
+                    return style(dstr[:1], fg=color1)+style(dstr[1:], fg=color2)
                 else:
                     return style(dstr[:1], bg=color1)+style(dstr[1:], bg=color2)
             else:

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -115,7 +115,7 @@ def str_week(week, today, collection=None,
             start = localize(datetime.datetime.combine(day, datetime.time.min))
             end = localize(datetime.datetime.combine(day, datetime.time.max))
             devents = collection.get_datetime_by_time_range(start, end) + \
-                      collection.get_allday_by_time_range(day)
+                collection.get_allday_by_time_range(day)
             if len(devents) > 0:
                 day = str_highlight_day(day, devents, hmethod, default_color,
                                         multiple, color)

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -73,13 +73,19 @@ def str_week(week, today, collection=None, conf=None):
             hconf = conf['highlight_days']
             hmethod = hconf['method']
             if hconf['color']=='':
-                dcolor = urwid_to_click(devents[0].color)
+                if devents[0].color=='':
+                    dcolorv = hconf['default_color']
+                    if dcolorv!='':
+                        dcolor = urwid_to_click(dcolorv)
+                else:
+                    dcolor = urwid_to_click(devents[0].color)
             else:
                 dcolor = urwid_to_click(hconf['color'])
-            if hmethod=="foreground" or hmethod=="fg":
-                day = style(dstr, fg=dcolor)
-            else:
-                day = style(dstr, bg=dcolor)
+            if dcolor!='':
+                if hmethod=="foreground" or hmethod=="fg":
+                    day = style(dstr, fg=dcolor)
+                else:
+                    day = style(dstr, bg=dcolor)
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -69,7 +69,7 @@ def str_week(week, today, collection=None):
         elif len(devents)>0:
             colors = devents[0].color.split()
             color = colors[len(colors)-1]
-            day = style(str(day.day).rjust(2), bg=color, fg='black')
+            day = style(str(day.day).rjust(2), fg=color)
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -59,15 +59,14 @@ def get_event_color(event, default_color):
     return event.color
 
 
-def str_highlight_day(day, devents, hconf):
+def str_highlight_day(day, devents, hmethod, default_color, multiple, color):
     """returns a string with day highlighted according to configuration
     """
     dstr = str(day.day).rjust(2)
-    hmethod = hconf['method']
-    if hconf['color'] == '':
-        dcolors = list(set(map(lambda x: get_event_color(x, hconf['default_color']), devents)))
+    if color == '':
+        dcolors = list(set(map(lambda x: get_event_color(x, default_color), devents)))
         if len(dcolors) > 1:
-            if hconf['multiple'] == '':
+            if multiple == '':
                 color1 = urwid_to_click(dcolors[0])
                 color2 = urwid_to_click(dcolors[1])
                 if hmethod == "foreground" or hmethod == "fg":
@@ -75,16 +74,16 @@ def str_highlight_day(day, devents, hconf):
                 else:
                     return style(dstr[:1], bg=color1) + style(dstr[1:], bg=color2)
             else:
-                dcolor = urwid_to_click(hconf['multiple'])
+                dcolor = urwid_to_click(multiple)
         else:
             if devents[0].color == '':
-                dcolorv = hconf['default_color']
+                dcolorv = default_color
                 if dcolorv != '':
                     dcolor = urwid_to_click(dcolorv)
             else:
                 dcolor = urwid_to_click(devents[0].color)
     else:
-        dcolor = urwid_to_click(hconf['color'])
+        dcolor = urwid_to_click(color)
     if dcolor != '':
         if hmethod == "foreground" or hmethod == "fg":
             return style(dstr, fg=dcolor)
@@ -115,7 +114,10 @@ def str_week(week, today, collection=None, conf=None):
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
         elif len(devents) > 0 and conf['default']['highlight_event_days'] != 0:
-            day = str_highlight_day(day, devents, conf['highlight_days'])
+            hconf = conf['highlight_days']
+            day = str_highlight_day(day, devents, hconf['method'],
+                                    hconf['default_color'], hconf['multiple'],
+                                    hconf['color'])
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -26,7 +26,7 @@ import datetime
 
 from click import style
 
-from terminal import urwid_to_click
+from .terminal import urwid_to_click
 
 from .compat import VERSION
 

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -51,6 +51,28 @@ def getweeknumber(date):
     return datetime.date.isocalendar(date)[1]
 
 
+def str_highlight_day(day, devents, hconf):
+    """returns a string with day highlighted according to configuration
+    """
+    dstr = str(day.day).rjust(2)
+    hmethod = hconf['method']
+    if hconf['color']=='':
+        if devents[0].color=='':
+            dcolorv = hconf['default_color']
+            if dcolorv!='':
+                dcolor = urwid_to_click(dcolorv)
+        else:
+            dcolor = urwid_to_click(devents[0].color)
+    else:
+        dcolor = urwid_to_click(hconf['color'])
+    if dcolor!='':
+        if hmethod=="foreground" or hmethod=="fg":
+            return style(dstr, fg=dcolor)
+        else:
+            return style(dstr, bg=dcolor)
+    return dstr
+
+
 def str_week(week, today, collection=None, conf=None):
     """returns a string representing one week,
     if for day == today colour is reversed
@@ -69,23 +91,7 @@ def str_week(week, today, collection=None, conf=None):
         if day == today:
             day = style(str(day.day).rjust(2), reverse=True)
         elif len(devents)>0 and conf['default']['highlight_event_days']!=0:
-            dstr = str(day.day).rjust(2)
-            hconf = conf['highlight_days']
-            hmethod = hconf['method']
-            if hconf['color']=='':
-                if devents[0].color=='':
-                    dcolorv = hconf['default_color']
-                    if dcolorv!='':
-                        dcolor = urwid_to_click(dcolorv)
-                else:
-                    dcolor = urwid_to_click(devents[0].color)
-            else:
-                dcolor = urwid_to_click(hconf['color'])
-            if dcolor!='':
-                if hmethod=="foreground" or hmethod=="fg":
-                    day = style(dstr, fg=dcolor)
-                else:
-                    day = style(dstr, bg=dcolor)
+            day = str_highlight_day(day, devents, conf['highlight_days'])
         else:
             day = str(day.day).rjust(2)
         strweek = strweek + day + ' '

--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -65,10 +65,15 @@ def str_highlight_day(day, devents, hconf):
     dstr = str(day.day).rjust(2)
     hmethod = hconf['method']
     if hconf['color']=='':
-        dcolors = map(lambda x: get_event_color(x, hconf['default_color']), devents)
+        dcolors = list(set(map(lambda x: get_event_color(x, hconf['default_color']), devents)))
         if len(dcolors)>1:
             if hconf['multiple']=='':
-                dcolor = urwid_to_click('light magenta')
+                color1 = urwid_to_click(dcolors[0])
+                color2 = urwid_to_click(dcolors[1])
+                if hmethod=="foreground" or hmethod=="fg":
+                    return style(dstr[0:0], fg=color1)+style(dstr[1:1], fg=color2)
+                else:
+                    return style(dstr[:1], bg=color1)+style(dstr[1:], bg=color2)
             else:
                 dcolor = urwid_to_click(hconf['multiple'])
         else:

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -231,7 +231,11 @@ def _get_cli():
             show_all_days=ctx.obj['conf']['default']['show_all_days'],
             days=days or ctx.obj['conf']['default']['days'],
             events=events,
-            conf=ctx.obj['conf']
+            hmethod=ctx.obj['conf']['highlight_days']['method'],
+            default_color=ctx.obj['conf']['highlight_days']['default_color'],
+            multiple=ctx.obj['conf']['highlight_days']['multiple'],
+            color=ctx.obj['conf']['highlight_days']['color'],
+            highlight_event_days=ctx.obj['conf']['default']['highlight_event_days']
         )
 
     @cli.command()

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -230,7 +230,8 @@ def _get_cli():
             weeknumber=ctx.obj['conf']['locale']['weeknumbers'],
             show_all_days=ctx.obj['conf']['default']['show_all_days'],
             days=days or ctx.obj['conf']['default']['days'],
-            events=events
+            events=events,
+            conf=ctx.obj['conf']
         )
 
     @cli.command()

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -140,10 +140,17 @@ def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
     event_column = get_agenda(
         collection, dates=date, width=rwidth, show_all_days=show_all_days,
         **kwargs)
+    hconf = conf['highlight_days']
     calendar_column = calendar_display.vertical_month(
         firstweekday=firstweekday, weeknumber=weeknumber,
-        collection=collection, conf=conf)
-
+        collection=collection,
+        hmethod=hconf['method'],
+        default_color=hconf['default_color'],
+        multiple=hconf['multiple'],
+        color=hconf['color'],
+        highlight_event_days=conf['default']['highlight_event_days'],
+        locale=conf['locale'])
+    
     rows = merge_columns(calendar_column, event_column)
     # XXX: Generate this as a unicode in the first place, rather than
     # casting it.

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -142,7 +142,6 @@ def calendar(collection, date=None, firstweekday=0, encoding='utf-8', locale=Non
     term_width, _ = get_terminal_size()
     lwidth = 25
     rwidth = term_width - lwidth - 4
-    print(kwargs)
     event_column = get_agenda(
         collection, locale, dates=date, width=rwidth, show_all_days=show_all_days,
         **kwargs)

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -129,7 +129,8 @@ def get_agenda(collection, locale, dates=None, firstweekday=0,
 
 
 def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
-             weeknumber=False, show_all_days=False, conf=None, **kwargs):
+             weeknumber=False, show_all_days=False, conf=None,
+             **kwargs):
     if date is None:
         date = [datetime.datetime.today()]
 

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -128,8 +128,13 @@ def get_agenda(collection, locale, dates=None, firstweekday=0,
     return event_column
 
 
-def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
+def calendar(collection, date=None, firstweekday=0, encoding='utf-8', locale=None,
              weeknumber=False, show_all_days=False, conf=None,
+             hmethod='fg',
+             default_color='',
+             multiple='',
+             color='',
+             highlight_event_days=0,
              **kwargs):
     if date is None:
         date = [datetime.datetime.today()]
@@ -137,19 +142,19 @@ def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
     term_width, _ = get_terminal_size()
     lwidth = 25
     rwidth = term_width - lwidth - 4
+    print(kwargs)
     event_column = get_agenda(
-        collection, dates=date, width=rwidth, show_all_days=show_all_days,
+        collection, locale, dates=date, width=rwidth, show_all_days=show_all_days,
         **kwargs)
-    hconf = conf['highlight_days']
     calendar_column = calendar_display.vertical_month(
         firstweekday=firstweekday, weeknumber=weeknumber,
         collection=collection,
-        hmethod=hconf['method'],
-        default_color=hconf['default_color'],
-        multiple=hconf['multiple'],
-        color=hconf['color'],
-        highlight_event_days=conf['default']['highlight_event_days'],
-        locale=conf['locale'])
+        hmethod=hmethod,
+        default_color=default_color,
+        multiple=multiple,
+        color=color,
+        highlight_event_days=highlight_event_days,
+        locale=locale)
     
     rows = merge_columns(calendar_column, event_column)
     # XXX: Generate this as a unicode in the first place, rather than

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -155,7 +155,6 @@ def calendar(collection, date=None, firstweekday=0, encoding='utf-8', locale=Non
         color=color,
         highlight_event_days=highlight_event_days,
         locale=locale)
-    
     rows = merge_columns(calendar_column, event_column)
     # XXX: Generate this as a unicode in the first place, rather than
     # casting it.

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -140,7 +140,8 @@ def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
         collection, dates=date, width=rwidth, show_all_days=show_all_days,
         **kwargs)
     calendar_column = calendar_display.vertical_month(
-        firstweekday=firstweekday, weeknumber=weeknumber)
+        firstweekday=firstweekday, weeknumber=weeknumber,
+        collection=collection)
 
     rows = merge_columns(calendar_column, event_column)
     # XXX: Generate this as a unicode in the first place, rather than

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -129,7 +129,7 @@ def get_agenda(collection, locale, dates=None, firstweekday=0,
 
 
 def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
-             weeknumber=False, show_all_days=False, **kwargs):
+             weeknumber=False, show_all_days=False, conf=None, **kwargs):
     if date is None:
         date = [datetime.datetime.today()]
 
@@ -141,7 +141,7 @@ def calendar(collection, date=None, firstweekday=0, encoding='utf-8',
         **kwargs)
     calendar_column = calendar_display.vertical_month(
         firstweekday=firstweekday, weeknumber=weeknumber,
-        collection=collection)
+        collection=collection, conf=conf)
 
     rows = merge_columns(calendar_column, event_column)
     # XXX: Generate this as a unicode in the first place, rather than

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -140,7 +140,7 @@ print_new = option('event', 'path', 'False', default=False)
 
 # If set to 1, khal will highlight days with events. Options for
 # highlighting are in [highlight_days] section.
-highlight_event_days = integer(default=0)
+highlight_event_days = boolean(default=False)
 
 # The view section contains config options that effect the visual appearance
 # when using ikhal

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -138,6 +138,10 @@ days = integer(default=2)
 # event in text form, the path to where the event is now saved or nothing?
 print_new = option('event', 'path', 'False', default=False)
 
+# If set to 1, khal will highlight days with events. Options for
+# highlighting are in [highlight_days] section.
+highlight_event_days = integer(default=0)
+
 # The view section contains config options that effect the visual appearance
 # when using ikhal
 [view]
@@ -166,3 +170,23 @@ theme = option('dark', 'light', default='dark')
 # Whether to show a visible frame (with *box drawing* characters) around some
 # (groups of) elements.
 frame = boolean(default=False)
+
+# When highlight_event_days is enabled, this section specifies how is
+# the highlighting rendered.
+[highlight_days]
+
+# Highlighting method to use - foreground or background
+method = option('foreground', 'fg', 'background', 'bg', default='fg')
+
+# What color to use when highlighting - explicit color or use calendar
+# color when set to ''
+color = option('black', 'white', 'brown', 'yellow','dark grey', 'dark green', 'dark blue','light grey', 'light green', 'light blue','dark magenta', 'dark cyan', 'dark red','light magenta', 'light cyan', 'light red', '', default='')
+
+# How to color days with events from multiple calendars - either
+# explicit color or use calendars' colors when set to ''
+multiple = option('black', 'white', 'brown', 'yellow','dark grey', 'dark green', 'dark blue','light grey', 'light green', 'light blue','dark magenta', 'dark cyan', 'dark red','light magenta', 'light cyan', 'light red', '', default='')
+
+# Default color for calendars without color - when se to '' it
+# actually disables highlighting for events that should use the
+# default color.
+default_color = option('black', 'white', 'brown', 'yellow','dark grey', 'dark green', 'dark blue','light grey', 'light green', 'light blue','dark magenta', 'dark cyan', 'dark red','light magenta', 'light cyan', 'light red', '', default='')

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -138,7 +138,7 @@ days = integer(default=2)
 # event in text form, the path to where the event is now saved or nothing?
 print_new = option('event', 'path', 'False', default=False)
 
-# If set to 1, khal will highlight days with events. Options for
+# If true, khal will highlight days with events. Options for
 # highlighting are in [highlight_days] section.
 highlight_event_days = boolean(default=False)
 

--- a/khal/terminal.py
+++ b/khal/terminal.py
@@ -99,4 +99,4 @@ def urwid_to_click(color):
     """convert urwid color name to click color name
     """
     colors = color.split()
-    return colors[len(colors)-1]
+    return colors[len(colors) - 1]

--- a/khal/terminal.py
+++ b/khal/terminal.py
@@ -93,3 +93,10 @@ def merge_columns(lcolumn, rcolumn, width=25):
     rows = ['    '.join(one) for one in zip_longest(
         lcolumn, rcolumn, fillvalue='')]
     return rows
+
+
+def urwid_to_click(color):
+    """convert urwid color name to click color name
+    """
+    colors = color.split()
+    return colors[len(colors)-1]

--- a/khal/terminal.py
+++ b/khal/terminal.py
@@ -98,5 +98,4 @@ def merge_columns(lcolumn, rcolumn, width=25):
 def urwid_to_click(color):
     """convert urwid color name to click color name
     """
-    colors = color.split()
-    return colors[len(colors) - 1]
+    return color.split()[-1]

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -42,7 +42,7 @@ class TestSettings(object):
                 'show_all_days': False,
                 'print_new': 'False',
                 'days': 2,
-                'highlight_event_days': 0
+                'highlight_event_days': False
             }
         }
         for key in comp_config:
@@ -82,7 +82,7 @@ class TestSettings(object):
                 'print_new': 'False',
                 'show_all_days': False,
                 'days': 2,
-                'highlight_event_days': 0
+                'highlight_event_days': False
             }
         }
         for key in comp_config:

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -42,6 +42,7 @@ class TestSettings(object):
                 'show_all_days': False,
                 'print_new': 'False',
                 'days': 2,
+                'highlight_event_days': 0
             }
         }
         for key in comp_config:
@@ -81,6 +82,7 @@ class TestSettings(object):
                 'print_new': 'False',
                 'show_all_days': False,
                 'days': 2,
+                'highlight_event_days': 0
             }
         }
         for key in comp_config:


### PR DESCRIPTION
Implemented highlighting of days with events in khal calendar display.

Fully configurable - foreground/background highlight, multiple colors for one day, defaults.

Not supported: "light"/bold colors. Right now the implementation just strips dark/light from the color name. Will add that later.