### PR TITLE
Fix error when trying to exclude calendars via cli

### DIFF
--- a/khal/cli.py
+++ b/khal/cli.py
@@ -75,7 +75,7 @@ def _multi_calendar_select_callback(ctx, option, calendars):
     elif mode == 'exclude_calendar':
         selection.update(ctx.obj['conf']['calendars'].keys())
         for value in calendars:
-            calendars.remove(value)
+            selection.remove(value)
     else:
         raise ValueError(mode)
 


### PR DESCRIPTION
Previous behaviour:
khal agenda -d some_calendar

    [...]
    AttributeError: 'tuple' object has no attribute 'remove'

Now:
works (calendar is being excluded)

Reported-by: @matthiasbeyer 