### PR TITLE
update and improve zsh completion file

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -14,3 +14,4 @@ Thomas Glanzmann - thomas [at] glanzmann [dot] de - https://thomas.glanzmann.de/
 John Shea - coachshea [at] fastmail [dot] com
 Dominik Joe Pantůček - joe [at] joe [dot] cz - http://joe.cz/
 Thomas Schaper - libreman [at] libremail [dot] nl
+Oliver Kiddle - okiddle [at] yahoo [dot] co [dot] uk

--- a/misc/__khal
+++ b/misc/__khal
@@ -5,34 +5,21 @@
 # fpath=(~/.zsh/completion $fpath) 
 
 _calendars() {
-  local accounts
-  accounts=( ${${(f)"$(command khal printcalendars 2> /dev/null)"}/[$'\n']##/} )
-  compadd "$a" ${(kv)=accounts}
+  local expl
+  _wanted calendars expl calendar compadd \
+      ${(f)"$(_call_program calendars khal printcalendars)"}
 }
 
-_ics_files() {
-  _files -g "*.ics"
-}
+local curcontext="$curcontext" hlp="--help" ret=1
+local -a args state line
+local -A opt_args
 
-local ret=1 state
-
-local -a common_ops
-common_ops=(
-  {-h,--help}"[show help]"
-  {-v,--verbose}"[give more output]"
-  --version"[show version and exit]"
-  {-q,--quiet}"[give less output]"
-  {-c,--config=}"[config file]:filename:_files"
-)
-
-_directories () {
-  _wanted directories expl directory _path_files -/ "$@" -
-}
-
-typeset -A opt_args
-_arguments \
+args=( '(- *)--help[show help information]' )
+_arguments -C $args \
+  {-c+,--config=}'[specify config file]:config file:_files' \
+  {-v,--verbose}"[give more output]" \
+  '(- *)--version[show version]' \
   ':subcommand:->subcommand' \
-  $common_ops \
   '*::options:->options' && ret=0
 
 case $state in
@@ -40,6 +27,7 @@ case $state in
     local -a subcommands
     subcommands=(
       "agenda:show agenda"
+      'at:show all events for given time'
       "calendar:show calendar"
       "interactive:open the interactive calendar"
       "import:import an ics file into a calendar"
@@ -53,28 +41,45 @@ case $state in
   ;;
 
   options)
-    local -a args
-    args=(
-      $common_ops
-    )
+    curcontext="${curcontext%:*}-${words[1]}:"
 
     case $words[1] in
-      calendar | agenda | interactive)
+      at | calendar | agenda | interactive | search | printcalendars )
         args+=(
-          "-a=[use this calendar]:calendars:_calendars"
-          "-b=[do not use this calendar]:calendars:_calendars"
+          "(-d --exclude-calendar $hlp)*"{-a+,--include-calendar=}'[specify calendar to use]:calendar:_calendars'
+          "(-a --include-calendar $hlp)*"{-d+,--exclude-calendar=}"[don't use this calendar]:calendar:_calendars"
+        )
+      ;|
+      agenda | calendar)
+        args+=(
+          "($hlp)--days=[specify how many days to include]:days:_dates -f d -F"
+          "($hlp)--events=[specify how many events so include]:events"
+        )
+      ;|
+      at | agenda) args+=( '*:date/time' ) ;;
+      new | import)
+        args+=(
+          "($hlp)-a+[specify calendar]:calendar:_calendars"
+        )
+      ;|
+      import)
+        args+=(
+          "(-r --random_uid $hlp)"{-r,--random_uid}'[select a random uid]'
+          "($hlp)--batch[don't ask for any confirmation]"
+          '*:file:_files -g "*.ics(-.)"'
         )
       ;;
-    import)
+      new)
         args+=(
-          "-a=[use this calendar]:calendars:_calendars"
-          "*:file:_ics_files"
-          --batch"[do not ask for any confirmation]"
+          "(-l --location $hlp)"{-l,--location=}'[specify location of event]:location'
+          "(-r --repeat $hlp)"{-r,--repeat=}'[repeat an event]:frequency:compadd -E0 - daily weekly monthly yearly'
+          "(-u --until $hlp)"{-u,--until=}'[specify date to stop an event repeating]:date'
+          ':start date/time' '::end date/time' '::timezone' ':summary' ':description'
         )
       ;;
     esac
 
-    _arguments $args && ret=0
+    _arguments -A "-*" $args && ret=0
   ;;
 esac
 


### PR DESCRIPTION
This improves the zsh completion. Firstly, I've tried to cover all new options and subcommands in the latest git version of khal. Other changes bring it in line with standard good practice for zsh completion functions: e.g. use of _wanted and _call_program, setting curcontext to include the subcommand, adding exclusion lists for mutually exclusive options. I've removed the superfluous redefinition  of _directories. I've only used _dates for completion after the agenda --days option. It'd be good if it could give a bit more of a clue as to the formats accepted for dates/times by khal new but I'm a little confused as to what actually is valid. Which of the configurable date formats are used? I also didn't use _time_zone for timezone completion because I'm not sure it is helpful. What formats are allowable for timezone? "UTC" doesn't seem to work while Europe/Berlin does. And specifying, e.g +0100 results in 'DTSTART has invalid or incomprehensible timezone information' messages.

One final comment: why is the function named with double underscores? Just _khal would be more conventional.