### PR TITLE
Fix broken path in doc/source/Makefile

### DIFF
--- a/doc/source/Makefile
+++ b/doc/source/Makefile
@@ -1,4 +1,4 @@
-configspec.rst: ../../../khal/khal/settings/khal.spec generate_config.py
+configspec.rst: ../../khal/settings/khal.spec generate_config.py
 	python generate_config.py > configspec.rst
 
 .PHONY: configspec.rst


### PR DESCRIPTION
In the 0.7 release tarball on PyPI [0], this path is broken, because the
tarball unpacks into 'khal-0.7.0' instead of 'khal'.

This bug prevents the documentation from being built.

This patch corrects the path, without depending on the name of the
top-level directory that the tarball unpacks into.

[0]
https://pypi.python.org/pypi/khal/0.7.0