### PR TITLE
Show birthdays for contacts with no FN

### DIFF
--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -552,7 +552,11 @@ class SQLiteDb_Birthdays(SQLiteDb):
                 logger.info('cannot parse BIRTHDAY in {} in collection '
                             '{}'.format(href, self.calendar))
                 return
-            name = vcard['FN']
+            if 'FN' in vcard:
+                name = vcard['FN']
+            else:
+                n = vcard['N'].split(';')
+                name = ' '.join([n[1], n[2], n[0]])
             event = icalendar.Event()
             event.add('dtstart', bday)
             event.add('dtend', bday + timedelta(days=1))

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -589,6 +589,13 @@ BDAY:x
 END:VCARD
 """
 
+card_no_fn = """BEGIN:VCARD
+VERSION:3.0
+N:Ritchie;Dennis;MacAlistair;;
+BDAY:19410909
+END:VCARD
+"""
+
 
 def test_birthdays(tmpdir):
     dbpath = str(tmpdir) + '/khal.db'
@@ -608,6 +615,16 @@ def test_birthdays_no_year(tmpdir):
     events = list(db.get_allday_range(date(1971, 3, 11)))
     assert len(events) == 1
     assert events[0].summary == 'Unix\'s birthday'
+
+
+def test_birthdays_no_fn(tmpdir):
+    dbpath = str(tmpdir) + '/khal.db'
+    db = backend.SQLiteDb_Birthdays('home', dbpath, locale=LOCALE_BERLIN)
+    assert list(db.get_allday_range(date(1941, 9, 9))) == list()
+    db.update(card_no_fn, 'unix.vcf')
+    events = list(db.get_allday_range(date(1941, 9, 9)))
+    assert len(events) == 1
+    assert events[0].summary == 'Dennis MacAlistair Ritchie\'s birthday'
 
 
 def test_birthday_does_not_parse(tmpdir):


### PR DESCRIPTION
Lots of my contacts don't have an `FN` so their birthdays are not listed. They *do* have `N`, so I used that instead.

[Related documentation](https://tools.ietf.org/html/rfc6350#section-6.2)

I'm not sure if this is always valid: are there scenarios in which the name orders should be different? Do we care about those?