### PR TITLE
Add __main__.py to make it easy to run khal from git.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -17,3 +17,4 @@ Thomas Schaper - libreman [at] libremail [dot] nl
 Oliver Kiddle - okiddle [at] yahoo [dot] co [dot] uk
 Filip Pytloun - filip [at] pytloun [dot] cz - https://fpy.cz
 Sebastian Hamann
+Lucas Hoffmann

--- a/khal/__main__.py
+++ b/khal/__main__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2013-2016 Christian Geier et al.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from .cli import main_khal
+
+if __name__ == '__main__':
+    main_khal()

--- a/khal/__main__.py
+++ b/khal/__main__.py
@@ -19,7 +19,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from .cli import main_khal
+from khal.cli import main_khal
 
 if __name__ == '__main__':
     main_khal()


### PR DESCRIPTION
By providing this __main__.py file it is easily possible to run khal from the
git repository without installing it first, like this:

cd /path/to/khal-repository
PYTHONPATH=. python -m khal