### PR TITLE
Remove redundant travis exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,3 @@ install:
 
 script:
     - "tox -e py-$BUILD"
-
-matrix:
-    exclude:
-        - python: pypy
-          env: BUILD=style


### PR DESCRIPTION
We don't test on pypy, so it's pointless to exclude a certain pypy build explicitly.