### PR TITLE
khal and ikhal: startup optimization with highlight_event_days = True

### DIFF
--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -462,8 +462,8 @@ class SQLiteDb(object):
                 'ORDER BY dtstart')
         else:
             sql_s = (
-                'SELECT item, recs_loc.href, dtstart, dtend, ref, etag, dtype, events.calendar FROM '
-                'recs_loc JOIN events ON '
+                'SELECT item, recs_loc.href, dtstart, dtend, ref, etag, dtype, events.calendar '
+                'FROM recs_loc JOIN events ON '
                 'recs_loc.href = events.href AND '
                 'recs_loc.calendar = events.calendar WHERE '
                 '(dtstart >= ? AND dtstart <= ? OR '
@@ -505,8 +505,8 @@ class SQLiteDb(object):
                 'ORDER BY dtstart')
         else:
             sql_s = (
-                'SELECT item, recs_float.href, dtstart, dtend, ref, etag, dtype, events.calendar FROM '
-                'recs_float JOIN events ON '
+                'SELECT item, recs_float.href, dtstart, dtend, ref, etag, dtype, events.calendar '
+                'FROM recs_float JOIN events ON '
                 'recs_float.href = events.href AND '
                 'recs_float.calendar = events.calendar WHERE '
                 '(dtstart >= ? AND dtstart < ? OR '

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -457,7 +457,8 @@ class SQLiteDb(object):
             'recs_loc.calendar = events.calendar WHERE '
             '(dtstart >= ? AND dtstart <= ? OR '
             'dtend > ? AND dtend <= ? OR '
-            'dtstart <= ? AND dtend >= ?) AND events.calendar in ({0});')
+            'dtstart <= ? AND dtend >= ?) AND events.calendar in ({0}) '
+            'ORDER BY dtstart')
         stuple = (start, end, start, end, start, end)
         result = self.sql_ex(sql_s.format(self._select_calendars), stuple)
         for item, href, start, end, ref, etag, dtype, calendar in result:
@@ -487,7 +488,8 @@ class SQLiteDb(object):
             'recs_float.calendar = events.calendar WHERE '
             '(dtstart >= ? AND dtstart < ? OR '
             'dtend > ? AND dtend <= ? OR '
-            'dtstart <= ? AND dtend > ? ) AND events.calendar in ({0});')
+            'dtstart <= ? AND dtend > ? ) AND events.calendar in ({0}) '
+            'ORDER BY dtstart')
         stuple = (strstart, strend, strstart, strend, strstart, strend)
         result = self.sql_ex(sql_s.format(self._select_calendars), stuple)
         for item, href, start, end, ref, etag, dtype, calendar in result:

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -452,7 +452,7 @@ class SQLiteDb(object):
         end = aux.to_unix_time(end)
         if minimal:
             sql_s = (
-                'SELECT recs_loc.href, dtstart, dtend, ref, etag, dtype, events.calendar FROM '
+                'SELECT events.calendar FROM '
                 'recs_loc JOIN events ON '
                 'recs_loc.href = events.href AND '
                 'recs_loc.calendar = events.calendar WHERE '
@@ -473,10 +473,8 @@ class SQLiteDb(object):
         stuple = (start, end, start, end, start, end)
         result = self.sql_ex(sql_s.format(self._select_calendars), stuple)
         if minimal:
-            for href, start, end, ref, etag, dtype, calendar in result:
-                start = pytz.UTC.localize(datetime.utcfromtimestamp(start))
-                end = pytz.UTC.localize(datetime.utcfromtimestamp(end))
-                yield EventStandIn(calendar)
+            for calendar in result:
+                yield EventStandIn(calendar[0])
         else:
             for item, href, start, end, ref, etag, dtype, calendar in result:
                 start = pytz.UTC.localize(datetime.utcfromtimestamp(start))
@@ -495,23 +493,35 @@ class SQLiteDb(object):
         assert end.tzinfo is None
         strstart = aux.to_unix_time(start)
         strend = aux.to_unix_time(end)
-        sql_s = (
-            'SELECT item, recs_float.href, dtstart, dtend, ref, etag, dtype, events.calendar FROM '
-            'recs_float JOIN events ON '
-            'recs_float.href = events.href AND '
-            'recs_float.calendar = events.calendar WHERE '
-            '(dtstart >= ? AND dtstart < ? OR '
-            'dtend > ? AND dtend <= ? OR '
-            'dtstart <= ? AND dtend > ? ) AND events.calendar in ({0}) '
-            'ORDER BY dtstart')
+        if minimal:
+            sql_s = (
+                'SELECT events.calendar FROM '
+                'recs_float JOIN events ON '
+                'recs_float.href = events.href AND '
+                'recs_float.calendar = events.calendar WHERE '
+                '(dtstart >= ? AND dtstart < ? OR '
+                'dtend > ? AND dtend <= ? OR '
+                'dtstart <= ? AND dtend > ? ) AND events.calendar in ({0}) '
+                'ORDER BY dtstart')
+        else:
+            sql_s = (
+                'SELECT item, recs_float.href, dtstart, dtend, ref, etag, dtype, events.calendar FROM '
+                'recs_float JOIN events ON '
+                'recs_float.href = events.href AND '
+                'recs_float.calendar = events.calendar WHERE '
+                '(dtstart >= ? AND dtstart < ? OR '
+                'dtend > ? AND dtend <= ? OR '
+                'dtstart <= ? AND dtend > ? ) AND events.calendar in ({0}) '
+                'ORDER BY dtstart')
         stuple = (strstart, strend, strstart, strend, strstart, strend)
         result = self.sql_ex(sql_s.format(self._select_calendars), stuple)
-        for item, href, start, end, ref, etag, dtype, calendar in result:
-            start = datetime.utcfromtimestamp(start)
-            end = datetime.utcfromtimestamp(end)
-            if minimal:
-                yield EventStandIn(calendar)
-            else:
+        if minimal:
+            for calendar in result:
+                yield EventStandIn(calendar[0])
+        else:
+            for item, href, start, end, ref, etag, dtype, calendar in result:
+                start = datetime.utcfromtimestamp(start)
+                end = datetime.utcfromtimestamp(end)
                 yield self.construct_event(item, href, start, end, ref, etag, calendar, dtype)
 
     def get_localized_at(self, dtime):

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -330,11 +330,12 @@ class CalendarCollection(object):
             return None
         if self.color != '':
             return 'highlight_days_color'
-        if len(devents) == 1:
-            return 'calendar ' + devents[0].calendar
+        dcalendars = list(set(map(lambda event: event.calendar, devents)))
+        if len(dcalendars) == 1:
+            return 'calendar ' + dcalendars[0]
         if self.multiple != '':
             return 'highlight_days_multiple'
-        return ('calendar ' + devents[0].calendar, 'calendar ' + devents[1].calendar)
+        return ('calendar ' + dcalendars[0], 'calendar ' + dcalendars[1])
 
     def get_styles(self, date, focus):
         if focus:

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -145,32 +145,6 @@ class CalendarCollection(object):
         events = self._backend.get_localized(start, end, minimal)
         return (self._cover_event(event) for event in events)
 
-    def merge_events(self, floating, localized):
-
-        """Merges two event generators into one while preserving order."""
-
-        try:
-            a = next(floating)
-        except StopIteration:
-            a = None
-        try:
-            b = next(localized)
-        except StopIteration:
-            b = None
-        while (a is not None) or (b is not None):
-            if a is not None and (b is None or a < b):
-                yield a
-                try:
-                    a = next(floating)
-                except StopIteration:
-                    a = None
-            else:
-                yield b
-                try:
-                    b = next(localized)
-                except StopIteration:
-                    b = None
-
     def get_events_on(self, day, minimal=False):
         """return all events on `day`
 
@@ -183,7 +157,7 @@ class CalendarCollection(object):
         localize = self._locale['local_timezone'].localize
         localized_events = self.get_localized(localize(start), localize(end), minimal)
 
-        return self.merge_events(floating_events, localized_events)
+        return itertools.chain(floating_events, localized_events)
 
     def get_events_at(self, dtime=datetime.datetime.now()):
         """get all events at datetime `dtime`


### PR DESCRIPTION
Backend optimization of get_localized and get_floating. Slight optimization in merging events for single day (floating+localized). And a fix for incorrectly highlighted days in ikhal.

The merging function is not necessary (it is only a small improvement over itertools) but it is somewhat faster and opens the possibility for more optimizations like generating whole week using single backend call.