### PR TITLE
WIP: Make events SQL query slightly lighter

### DIFF
--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -451,17 +451,7 @@ class SQLiteDb(object):
         start = aux.to_unix_time(start)
         end = aux.to_unix_time(end)
         if minimal:
-            sql_s = (
-                'SELECT events.calendar FROM '
-                'recs_loc JOIN events ON '
-                'recs_loc.href = events.href AND '
-                'recs_loc.calendar = events.calendar WHERE '
-                '(dtstart BETWEEN ? AND ? OR '
-                'dtend BETWEEN ? AND ? OR '
-                '? BETWEEN dtstart AND dtend OR '
-                '? BETWEEN dtstart AND dtend) '
-                'AND events.calendar in ({0}) '
-                'ORDER BY dtstart')
+            sql_s = 'SELECT events.calendar FROM events'
         else:
             sql_s = (
                 'SELECT item, recs_loc.href, dtstart, dtend, ref, etag, dtype, events.calendar '

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -456,9 +456,11 @@ class SQLiteDb(object):
                 'recs_loc JOIN events ON '
                 'recs_loc.href = events.href AND '
                 'recs_loc.calendar = events.calendar WHERE '
-                '(dtstart >= ? AND dtstart <= ? OR '
-                'dtend > ? AND dtend <= ? OR '
-                'dtstart <= ? AND dtend >= ?) AND events.calendar in ({0}) '
+                '(dtstart BETWEEN ? AND ? OR '
+                'dtend BETWEEN ? AND ? OR '
+                '? BETWEEN dtstart AND dtend OR '
+                '? BETWEEN dtstart AND dtend) '
+                'AND events.calendar in ({0}) '
                 'ORDER BY dtstart')
         else:
             sql_s = (
@@ -466,9 +468,11 @@ class SQLiteDb(object):
                 'FROM recs_loc JOIN events ON '
                 'recs_loc.href = events.href AND '
                 'recs_loc.calendar = events.calendar WHERE '
-                '(dtstart >= ? AND dtstart <= ? OR '
-                'dtend > ? AND dtend <= ? OR '
-                'dtstart <= ? AND dtend >= ?) AND events.calendar in ({0}) '
+                '(dtstart BETWEEN ? AND ? OR '
+                'dtend BETWEEN ? AND ? OR '
+                '? BETWEEN dtstart AND dtend OR '
+                '? BETWEEN dtstart AND dtend) '
+                'AND events.calendar in ({0}) '
                 'ORDER BY dtstart')
         stuple = (start, end, start, end, start, end)
         result = self.sql_ex(sql_s.format(self._select_calendars), stuple)


### PR DESCRIPTION
Use BETWEEN to determine if a date is inside a range. This is ligher since SQLite will optimize that. From the BETWEEN documentation:

> The BETWEEN operator is logically equivalent to a pair of comparisons. "x BETWEEN y AND z" is equivalent to "x>=y AND x<=z" except that with BETWEEN, the x expression is only evaluated once. The precedence of the BETWEEN operator is the same as the precedence as operators == and != and LIKE and groups left to right.